### PR TITLE
Add a default value for the RosettaProperty, it has become clear that th...

### DIFF
--- a/RosettaAnnotations/src/main/java/com/hubspot/rosetta/annotations/RosettaProperty.java
+++ b/RosettaAnnotations/src/main/java/com/hubspot/rosetta/annotations/RosettaProperty.java
@@ -17,5 +17,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @RosettaAnnotation
 public @interface RosettaProperty {
-  String value();
+
+  String USE_DEFAULT_NAME = "";
+
+  String value() default USE_DEFAULT_NAME;
 }

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/RosettaPropertyTest.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/RosettaPropertyTest.java
@@ -11,20 +11,23 @@ import java.io.IOException;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 public class RosettaPropertyTest {
-  private static final String JSON = "{\"mccartney_song_title\":\"Hey Jude\"}";
+  private static final String JSON = "{\"jsonIgnoreRosettaUse\":\"Here\",\"mccartney_song_title\":\"Hey Jude\"}";
   private static final String JACKSON_JSON = "{\"mcCartneySongTitle\":\"Hey Jude\"}";
 
   @Test
   public void itWritesWithThePropertyName() throws JsonProcessingException {
     RosettaPropertyBean bean = new RosettaPropertyBean();
     bean.setMcCartneySongTitle("Hey Jude");
+    bean.setJsonIgnoreRosettaUse("Here");
     assertThat(Rosetta.getMapper().writeValueAsString(bean)).isEqualTo(JSON);
     assertThat(new ObjectMapper().writeValueAsString(bean)).isEqualTo(JACKSON_JSON);
   }
 
   @Test
   public void itReadsThePropertyName() throws IOException {
-    assertThat(Rosetta.getMapper().readValue(JSON, RosettaPropertyBean.class).getMcCartneySongTitle()).isEqualTo("Hey Jude");
+    RosettaPropertyBean rosettaRead = Rosetta.getMapper().readValue(JSON, RosettaPropertyBean.class);
+    assertThat(rosettaRead.getMcCartneySongTitle()).isEqualTo("Hey Jude");
+    assertThat(rosettaRead.getJsonIgnoreRosettaUse()).isEqualTo("Here");
     assertThat(new ObjectMapper().readValue(JACKSON_JSON, RosettaPropertyBean.class).getMcCartneySongTitle()).isEqualTo("Hey Jude");
   }
 }

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/RosettaPropertyBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/RosettaPropertyBean.java
@@ -1,10 +1,15 @@
 package com.hubspot.rosetta.beans;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hubspot.rosetta.annotations.RosettaProperty;
 
 public class RosettaPropertyBean {
   @RosettaProperty("mccartney_song_title")
   private String mcCartneySongTitle;
+
+  @RosettaProperty
+  @JsonIgnore
+  private String jsonIgnoreRosettaUse;
 
   public String getMcCartneySongTitle() {
     return mcCartneySongTitle;
@@ -12,6 +17,15 @@ public class RosettaPropertyBean {
 
   public RosettaPropertyBean setMcCartneySongTitle(String mcCartneySongTitle) {
     this.mcCartneySongTitle = mcCartneySongTitle;
+    return this;
+  }
+
+  public String getJsonIgnoreRosettaUse() {
+    return jsonIgnoreRosettaUse;
+  }
+
+  public RosettaPropertyBean setJsonIgnoreRosettaUse(String jsonIgnoreRosettaUse) {
+    this.jsonIgnoreRosettaUse = jsonIgnoreRosettaUse;
     return this;
   }
 }


### PR DESCRIPTION
...is can be used in conjunction with an @JsonIgnore so that rosetta uses the value, when jackson does not.
thanks to @jkebinger for the impetus.
@HiJon89 