### PR TITLE
Add an override of the jackson databind module so that users can

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ You can then register it with Rosetta programmatically during your app's startup
 Rosetta.addModule(new LowerCaseWithUnderscoresModule());
 ```
 
-Or even better, you can create a file located at  
+Or even better your module could extend `com.hubspot.rosetta.databind.DatabindModule`, you can create a file located at
+`src/main/resources/META-INF/services/com.hubspot.rosetta.databind.DatabindModule`
+
+Rosetta also supports injecting from the default Module:
 `src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module`  
-containing a newline separated list of fully qualified class names for the modules you want to load, in this case it would contain something like  
+
+Both files should contain a newline separated list of fully qualified class names for the modules you want to load, in this case it would contain something like  
 `your.package.LowerCaseWithUnderscoresModule`

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ You can then register it with Rosetta programmatically during your app's startup
 Rosetta.addModule(new LowerCaseWithUnderscoresModule());
 ```
 
-Or even better your module could extend `com.hubspot.rosetta.databind.DatabindModule`, you can create a file located at
-`src/main/resources/META-INF/services/com.hubspot.rosetta.databind.DatabindModule`
+Or even better your module could extend `com.hubspot.rosetta.databind.AutoDiscoveredModule`, you can create a file located at
+`src/main/resources/META-INF/services/com.hubspot.rosetta.databind.AutoDiscoveredModule`
 
 Rosetta also supports injecting from the default Module:
 `src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module`  

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/Rosetta.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/Rosetta.java
@@ -2,6 +2,7 @@ package com.hubspot.rosetta;
 
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.rosetta.databind.DatabindModule;
 import com.hubspot.rosetta.internal.RosettaModule;
 
 import java.util.ArrayList;
@@ -58,6 +59,10 @@ public enum Rosetta {
   private static List<Module> defaultModules() {
     List<Module> defaultModules = new ArrayList<Module>();
     defaultModules.add(new RosettaModule());
+
+    for (Module module : ServiceLoader.load(DatabindModule.class)) {
+      defaultModules.add(module);
+    }
 
     for (Module module : ServiceLoader.load(Module.class)) {
       defaultModules.add(module);

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/Rosetta.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/Rosetta.java
@@ -2,7 +2,7 @@ package com.hubspot.rosetta;
 
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hubspot.rosetta.databind.DatabindModule;
+import com.hubspot.rosetta.databind.AutoDiscoveredModule;
 import com.hubspot.rosetta.internal.RosettaModule;
 
 import java.util.ArrayList;
@@ -60,7 +60,7 @@ public enum Rosetta {
     List<Module> defaultModules = new ArrayList<Module>();
     defaultModules.add(new RosettaModule());
 
-    for (Module module : ServiceLoader.load(DatabindModule.class)) {
+    for (Module module : ServiceLoader.load(AutoDiscoveredModule.class)) {
       defaultModules.add(module);
     }
 

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/databind/AutoDiscoveredModule.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/databind/AutoDiscoveredModule.java
@@ -2,5 +2,5 @@ package com.hubspot.rosetta.databind;
 
 import com.fasterxml.jackson.databind.Module;
 
-public abstract class DatabindModule extends Module {
+public abstract class AutoDiscoveredModule extends Module {
 }

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/databind/DatabindModule.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/databind/DatabindModule.java
@@ -1,0 +1,6 @@
+package com.hubspot.rosetta.databind;
+
+import com.fasterxml.jackson.databind.Module;
+
+public abstract class DatabindModule extends Module {
+}


### PR DESCRIPTION
separate out their rosetta specific changes

@HiJon89 This means we can create data binding modules that we want to use on rosetta, without affecting other jackson utilities.