### PR TITLE
Allow for passing ObjectMapper to RosettaMapperFactory rather than relying upon Rosetta Singleton

### DIFF
--- a/RosettaCore/src/main/java/com/hubspot/rosetta/RosettaMapper.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/RosettaMapper.java
@@ -1,5 +1,6 @@
 package com.hubspot.rosetta;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.rosetta.internal.TableNameExtractor;
 
 import java.sql.ResultSet;
@@ -22,14 +23,20 @@ public class RosettaMapper<T> {
 
   private final Class<T> type;
   private final String tableName;
+  private final ObjectMapper om;
 
-  public RosettaMapper(Class<T> type) {
-    this(type, null);
+  public RosettaMapper(Class<T> type, ObjectMapper om) {
+    this(type, om, null);
   }
 
   public RosettaMapper(Class<T> type, String tableName) {
+    this(type, Rosetta.getMapper(), tableName);
+  }
+
+  public RosettaMapper(Class<T> type, ObjectMapper om, String tableName) {
     this.type = type;
     this.tableName = tableName;
+    this.om = om;
   }
 
   /**
@@ -68,7 +75,7 @@ public class RosettaMapper<T> {
       add(map, label, value, overwrite);
     }
 
-    return Rosetta.getMapper().convertValue(map, type);
+    return om.convertValue(map, type);
   }
 
   private void add(Map<String, Object> map, String label, Object value, boolean overwrite) {

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
-import com.hubspot.rosetta.Rosetta;
 import com.hubspot.rosetta.annotations.RosettaCreator;
 import com.hubspot.rosetta.annotations.RosettaNaming;
 import com.hubspot.rosetta.annotations.RosettaProperty;

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
@@ -3,11 +3,13 @@ package com.hubspot.rosetta.internal;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
+import com.hubspot.rosetta.Rosetta;
 import com.hubspot.rosetta.annotations.RosettaCreator;
 import com.hubspot.rosetta.annotations.RosettaNaming;
 import com.hubspot.rosetta.annotations.RosettaProperty;
@@ -16,6 +18,11 @@ import com.hubspot.rosetta.annotations.StoredAsJson;
 
 public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
   private static final long serialVersionUID = 1L;
+  private final ObjectMapper om;
+
+  public RosettaAnnotationIntrospector(ObjectMapper om) {
+    this.om = om;
+  }
 
   @Override
   public Object findNamingStrategy(AnnotatedClass ac) {
@@ -47,7 +54,7 @@ public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
       }
 
       String empty = StoredAsJson.NULL.equals(storedAsJson.empty()) ? null : storedAsJson.empty();
-      return new StoredAsJsonDeserializer(a.getRawType(), a.getGenericType(), empty);
+      return new StoredAsJsonDeserializer(a.getRawType(), a.getGenericType(), empty, om);
     }
   }
 

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaModule.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaModule.java
@@ -22,11 +22,14 @@ public class RosettaModule extends Module {
 
   @Override
   public void setupModule(SetupContext context) {
-    context.insertAnnotationIntrospector(new RosettaAnnotationIntrospector());
+
     context.addBeanSerializerModifier(new StoredAsJsonBeanSerializerModifier());
 
     ObjectCodec codec = context.getOwner();
     if (codec instanceof ObjectMapper) {
+
+      context.insertAnnotationIntrospector(new RosettaAnnotationIntrospector((ObjectMapper) codec));
+
       ObjectMapper mapper = (ObjectMapper) codec;
       mapper.setSerializerProvider(new DefaultSerializerProvider.Impl());
       mapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/StoredAsJsonDeserializer.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/StoredAsJsonDeserializer.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
-import com.hubspot.rosetta.Rosetta;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -18,11 +17,13 @@ public class StoredAsJsonDeserializer<T> extends StdScalarDeserializer<T> {
   private static final long serialVersionUID = 1L;
   private final Type type;
   private final String defaultValue;
+  private final ObjectMapper om;
 
-  public StoredAsJsonDeserializer(Class<T> vc, Type type, String defaultValue) {
+  public StoredAsJsonDeserializer(Class<T> vc, Type type, String defaultValue, ObjectMapper om) {
     super(vc);
     this.type = type;
     this.defaultValue = defaultValue;
+    this.om = om;
   }
 
   @Override
@@ -45,7 +46,7 @@ public class StoredAsJsonDeserializer<T> extends StdScalarDeserializer<T> {
   @Override
   public T getNullValue() {
     try {
-      return deserialize(Rosetta.getMapper(), null, Rosetta.getMapper().constructType(type));
+      return deserialize(om, null, om.constructType(type));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/RosettaJdbi/src/main/java/com/hubspot/rosetta/jdbi/RosettaMapperFactory.java
+++ b/RosettaJdbi/src/main/java/com/hubspot/rosetta/jdbi/RosettaMapperFactory.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.rosetta.Rosetta;
 import org.skife.jdbi.v2.ResultSetMapperFactory;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
@@ -28,6 +30,17 @@ public class RosettaMapperFactory implements ResultSetMapperFactory {
           java.sql.Timestamp.class
   ));
 
+  private final ObjectMapper om;
+
+  public RosettaMapperFactory(){
+        om = Rosetta.getMapper();
+  }
+
+  public RosettaMapperFactory(ObjectMapper om) {
+      this.om = om;
+
+  }
+
   @Override
   public boolean accepts(@SuppressWarnings("rawtypes") Class type, StatementContext ctx) {
     return !(type.isPrimitive() || type.isArray() || type.isAnnotation() || BLACKLIST.contains(type));
@@ -36,7 +49,7 @@ public class RosettaMapperFactory implements ResultSetMapperFactory {
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
   public ResultSetMapper mapperFor(Class type, StatementContext ctx) {
-    final RosettaMapper mapper = new RosettaMapper(type, extractTableName(ctx.getRewrittenSql()));
+    final RosettaMapper mapper = new RosettaMapper(type, om, extractTableName(ctx.getRewrittenSql()));
 
     return new ResultSetMapper() {
 


### PR DESCRIPTION
I made some basic changes to allow for passing an ObjectMapper instance to RosettaMapperFactory so that the factory can be customized at the Handle or DBI level for deserialization. Unfortunately, it seems that doing the same for binding is incompatible with the current design of JDBI.
