### PR TITLE
Don't use StringSerializer#serialize in ConstantSerializer

### DIFF
--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/ConstantSerializer.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/ConstantSerializer.java
@@ -1,5 +1,8 @@
 package com.hubspot.rosetta.internal;
 
+import java.io.IOException;
+import java.lang.reflect.Type;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -7,9 +10,6 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.ser.std.NonTypedScalarSerializerBase;
 import com.fasterxml.jackson.databind.ser.std.StringSerializer;
-
-import java.io.IOException;
-import java.lang.reflect.Type;
 
 public class ConstantSerializer extends NonTypedScalarSerializerBase<Object> {
   private static final StringSerializer DELEGATE = new StringSerializer();
@@ -23,7 +23,7 @@ public class ConstantSerializer extends NonTypedScalarSerializerBase<Object> {
 
   @Override
   public void serialize(Object ignored, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-    DELEGATE.serialize(value, jgen, provider);
+    jgen.writeString(value);
   }
 
   @Override


### PR DESCRIPTION
This addresses the same Jackson binary compatibility issue (this time seen in `2.7.9`) as https://github.com/HubSpot/Rosetta/issues/23. 

```
java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.ser.std.StringSerializer.serialize(Ljava/lang/String;Lcom/fasterxml/jackson/core/JsonGenerator;Lcom/fasterxml/jackson/databind/SerializerProvider;)V
	at com.hubspot.rosetta.internal.ConstantSerializer.serialize(ConstantSerializer.java:26)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:639)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:678)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:157)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:130)
	at com.fasterxml.jackson.databind.ObjectMapper.writeValue(ObjectMapper.java:2444)
	at com.fasterxml.jackson.databind.ObjectMapper.valueToTree(ObjectMapper.java:2586)
```

@jhaber 