### PR TITLE
Add RosettaObjectMapperOverride#override(IDBI)

### DIFF
--- a/RosettaJdbi/src/main/java/com/hubspot/rosetta/jdbi/RosettaObjectMapperOverride.java
+++ b/RosettaJdbi/src/main/java/com/hubspot/rosetta/jdbi/RosettaObjectMapperOverride.java
@@ -1,12 +1,14 @@
 package com.hubspot.rosetta.jdbi;
 
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.IDBI;
+import org.skife.jdbi.v2.SQLStatement;
+import org.skife.jdbi.v2.StatementContext;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.rosetta.Rosetta;
 import com.hubspot.rosetta.internal.RosettaModule;
-import org.skife.jdbi.v2.DBI;
-import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.SQLStatement;
-import org.skife.jdbi.v2.StatementContext;
 
 public class RosettaObjectMapperOverride {
   public static final String ATTRIBUTE_NAME = "_rosetta_object_mapper";
@@ -18,6 +20,10 @@ public class RosettaObjectMapperOverride {
   }
 
   public void override(DBI dbi) {
+    override((IDBI) dbi);
+  }
+
+  public void override(IDBI dbi) {
     dbi.define(ATTRIBUTE_NAME, objectMapper);
   }
 


### PR DESCRIPTION
We deal with `IDBI` in lots of places and shouldn't have to blindly cast to `DBI`

@jhaber 
cc @szabowexler 