### PR TITLE
Handle obscure case where `@StoredAsJson` on `List<Foo> getFoos()` is…

### DIFF
--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
@@ -71,7 +71,7 @@ public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
     }
     if (storedAsJson != null) {
       if (a instanceof AnnotatedMethod) {
-        a = ((AnnotatedMethod) a).getParameter(0);
+        a = getAnnotatedTypeFromAnnotatedMethod((AnnotatedMethod) a);
       }
 
       String empty = StoredAsJson.NULL.equals(storedAsJson.empty()) ? "null" : storedAsJson.empty();
@@ -144,6 +144,16 @@ public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
       return ann.value().isEmpty() ? PropertyName.USE_DEFAULT : new PropertyName(ann.value());
     }
     return null;
+  }
+
+  private Annotated getAnnotatedTypeFromAnnotatedMethod(AnnotatedMethod a) {
+    if (a.getParameterCount() > 0) {
+      return a.getParameter(0);
+    } else if (a.hasReturnType()) {
+      return a;
+    } else {
+      throw new IllegalArgumentException("Cannot have @StoredAsJson on a method with no parameters AND no arguments");
+    }
   }
 
   private Type getType(Annotated a) {

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonListTypeInfoBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonListTypeInfoBean.java
@@ -14,7 +14,6 @@ import com.hubspot.rosetta.beans.StoredAsJsonListTypeInfoBean.ConcreteStoredAsJs
     @JsonSubTypes.Type(value = ConcreteStoredAsJsonList.class)
 })
 public abstract class StoredAsJsonListTypeInfoBean {
-
   @StoredAsJson
   public abstract List<InnerBean> getInnerBeans();
 

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonListTypeInfoBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonListTypeInfoBean.java
@@ -1,0 +1,33 @@
+package com.hubspot.rosetta.beans;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.hubspot.rosetta.annotations.StoredAsJson;
+import com.hubspot.rosetta.beans.StoredAsJsonListTypeInfoBean.ConcreteStoredAsJsonList;
+
+@JsonTypeInfo(use = Id.CLASS, include = As.PROPERTY)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ConcreteStoredAsJsonList.class)
+})
+public abstract class StoredAsJsonListTypeInfoBean {
+
+  @StoredAsJson
+  public abstract List<InnerBean> getInnerBeans();
+
+  public static class ConcreteStoredAsJsonList extends StoredAsJsonListTypeInfoBean {
+    private List<InnerBean> innerBeans;
+
+    @Override
+    public List<InnerBean> getInnerBeans() {
+      return innerBeans;
+    }
+
+    public void setInnerBeans(List<InnerBean> innerBeans) {
+      this.innerBeans = innerBeans;
+    }
+  }
+}


### PR DESCRIPTION
… in a JsonTypeInfo, and we don't get the setter method.

Strange case where our top class is abstract, with `@JsonTypeInfo`, and our `@StoredAsJson` is a list.  If it's not a list, then everything already works.