### PR TITLE
Creating tests to show that `@StoredAsJson` works for generic `@JsonT…

### DIFF
--- a/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/StoredAsJsonTest.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/StoredAsJsonTest.java
@@ -20,6 +20,8 @@ import com.hubspot.rosetta.beans.InnerBean;
 import com.hubspot.rosetta.beans.StoredAsJsonBean;
 import com.hubspot.rosetta.beans.StoredAsJsonListTypeInfoBean;
 import com.hubspot.rosetta.beans.StoredAsJsonListTypeInfoBean.ConcreteStoredAsJsonList;
+import com.hubspot.rosetta.beans.StoredAsJsonTypeInfoBean;
+import com.hubspot.rosetta.beans.StoredAsJsonTypeInfoBean.ConcreteStoredAsJsonTypeInfo;
 
 public class StoredAsJsonTest {
   private StoredAsJsonBean bean;
@@ -28,11 +30,19 @@ public class StoredAsJsonTest {
   private final JsonNode expected = TextNode.valueOf("{\"stringProperty\":\"value\"}");
   private final JsonNode expectedBinary = BinaryNode.valueOf(expected.textValue().getBytes(StandardCharsets.UTF_8));
 
+  private StoredAsJsonTypeInfoBean typeInfoBean;
+  private final JsonNode expectedTypeInfo = TextNode.valueOf("{\"generalValue\":\"General\",\"concreteValue\":\"internal\",\"type\":\"concrete\"}");
+
   @Before
   public void setup() {
     bean = new StoredAsJsonBean();
     inner = new InnerBean();
     inner.setStringProperty("value");
+
+    ConcreteStoredAsJsonTypeInfo concrete = new ConcreteStoredAsJsonTypeInfo();
+    concrete.setGeneralValue("General");
+    concrete.setConcreteValue("internal");
+    typeInfoBean = concrete;
   }
 
   @Test
@@ -423,5 +433,130 @@ public class StoredAsJsonTest {
                    .get(0)
                    .getStringProperty())
         .isEqualTo("value");
+  }
+
+  @Test
+  public void itHandlesAnnotatedOptionalGenericFieldSerialization() {
+    bean.setOptionalTypeInfoField(Optional.of(typeInfoBean));
+
+    assertThat(Rosetta.getMapper().valueToTree(bean).get("optionalTypeInfoField"))
+        .isEqualTo(expectedTypeInfo);
+  }
+
+  @Test
+  public void itHandlesAnnotatedOptionalGenericFieldDeserialization() throws JsonProcessingException {
+    ObjectNode node = Rosetta.getMapper().createObjectNode();
+    node.put("optionalTypeInfoField", expectedTypeInfo);
+
+    StoredAsJsonBean bean = Rosetta.getMapper().treeToValue(node, StoredAsJsonBean.class);
+    assertThat(bean.getOptionalTypeInfoField().isPresent()).isTrue();
+    assertThat(bean.getOptionalTypeInfoField().get()).isInstanceOf(ConcreteStoredAsJsonTypeInfo.class);
+    assertThat(bean.getOptionalTypeInfoField().get().getGeneralValue()).isEqualTo("General");
+    assertThat(((ConcreteStoredAsJsonTypeInfo) bean.getOptionalTypeInfoField().get()).getConcreteValue())
+        .isEqualTo("internal");
+  }
+
+  @Test
+  public void itHandlesAnnotatedOptionalGenericGetterSerialization() {
+    bean.setOptionalTypeInfoGetter(Optional.of(typeInfoBean));
+
+    assertThat(Rosetta.getMapper().valueToTree(bean).get("optionalTypeInfoGetter"))
+        .isEqualTo(expectedTypeInfo);
+  }
+
+  @Test
+  public void itHandlesAnnotatedOptionalGenericGetterDeserialization() throws JsonProcessingException {
+    ObjectNode node = Rosetta.getMapper().createObjectNode();
+    node.put("optionalTypeInfoGetter", expectedTypeInfo);
+
+    StoredAsJsonBean bean = Rosetta.getMapper().treeToValue(node, StoredAsJsonBean.class);
+    assertThat(bean.getOptionalTypeInfoGetter().isPresent()).isTrue();
+    assertThat(bean.getOptionalTypeInfoGetter().get()).isInstanceOf(ConcreteStoredAsJsonTypeInfo.class);
+    assertThat(bean.getOptionalTypeInfoGetter().get().getGeneralValue()).isEqualTo("General");
+    assertThat(((ConcreteStoredAsJsonTypeInfo) bean.getOptionalTypeInfoGetter().get()).getConcreteValue())
+        .isEqualTo("internal");
+  }
+  @Test
+  public void itHandlesAnnotatedOptionalGenericSetterSerialization() {
+    bean.setOptionalTypeInfoSetter(Optional.of(typeInfoBean));
+
+    assertThat(Rosetta.getMapper().valueToTree(bean).get("optionalTypeInfoSetter"))
+        .isEqualTo(expectedTypeInfo);
+  }
+
+  @Test
+  public void itHandlesAnnotatedOptionalGenericSetterDeserialization() throws JsonProcessingException {
+    ObjectNode node = Rosetta.getMapper().createObjectNode();
+    node.put("optionalTypeInfoSetter", expectedTypeInfo);
+
+    StoredAsJsonBean bean = Rosetta.getMapper().treeToValue(node, StoredAsJsonBean.class);
+    assertThat(bean.getOptionalTypeInfoSetter().isPresent()).isTrue();
+    assertThat(bean.getOptionalTypeInfoSetter().get()).isInstanceOf(ConcreteStoredAsJsonTypeInfo.class);
+    assertThat(bean.getOptionalTypeInfoSetter().get().getGeneralValue()).isEqualTo("General");
+    assertThat(((ConcreteStoredAsJsonTypeInfo) bean.getOptionalTypeInfoSetter().get()).getConcreteValue())
+        .isEqualTo("internal");
+  }
+
+  @Test
+  public void itHandlesAnnotatedGenericFieldSerialization() {
+    bean.setTypeInfoField(typeInfoBean);
+
+    assertThat(Rosetta.getMapper().valueToTree(bean).get("typeInfoField"))
+        .isEqualTo(expectedTypeInfo);
+  }
+
+  @Test
+  public void itHandlesAnnotatedGenericFieldDeserialization() throws JsonProcessingException {
+    ObjectNode node = Rosetta.getMapper().createObjectNode();
+    node.put("typeInfoField", expectedTypeInfo);
+
+    StoredAsJsonBean bean = Rosetta.getMapper().treeToValue(node, StoredAsJsonBean.class);
+    assertThat(bean.getTypeInfoField()).isNotNull();
+    assertThat(bean.getTypeInfoField()).isInstanceOf(ConcreteStoredAsJsonTypeInfo.class);
+    assertThat(bean.getTypeInfoField().getGeneralValue()).isEqualTo("General");
+    assertThat(((ConcreteStoredAsJsonTypeInfo) bean.getTypeInfoField()).getConcreteValue())
+        .isEqualTo("internal");
+  }
+
+  @Test
+  public void itHandlesAnnotatedGenericGetterSerialization() {
+    bean.setTypeInfoGetter(typeInfoBean);
+
+    assertThat(Rosetta.getMapper().valueToTree(bean).get("typeInfoGetter"))
+        .isEqualTo(expectedTypeInfo);
+  }
+
+  @Test
+  public void itHandlesAnnotatedGenericGetterDeserialization() throws JsonProcessingException {
+    ObjectNode node = Rosetta.getMapper().createObjectNode();
+    node.put("typeInfoGetter", expectedTypeInfo);
+
+    StoredAsJsonBean bean = Rosetta.getMapper().treeToValue(node, StoredAsJsonBean.class);
+    assertThat(bean.getTypeInfoGetter()).isNotNull();
+    assertThat(bean.getTypeInfoGetter()).isInstanceOf(ConcreteStoredAsJsonTypeInfo.class);
+    assertThat(bean.getTypeInfoGetter().getGeneralValue()).isEqualTo("General");
+    assertThat(((ConcreteStoredAsJsonTypeInfo) bean.getTypeInfoGetter()).getConcreteValue())
+        .isEqualTo("internal");
+  }
+
+  @Test
+  public void itHandlesAnnotatedGenericSetterSerialization() {
+    bean.setTypeInfoSetter(typeInfoBean);
+
+    assertThat(Rosetta.getMapper().valueToTree(bean).get("typeInfoSetter"))
+        .isEqualTo(expectedTypeInfo);
+  }
+
+  @Test
+  public void itHandlesAnnotatedGenericSetterDeserialization() throws JsonProcessingException {
+    ObjectNode node = Rosetta.getMapper().createObjectNode();
+    node.put("typeInfoSetter", expectedTypeInfo);
+
+    StoredAsJsonBean bean = Rosetta.getMapper().treeToValue(node, StoredAsJsonBean.class);
+    assertThat(bean.getTypeInfoSetter()).isNotNull();
+    assertThat(bean.getTypeInfoSetter()).isInstanceOf(ConcreteStoredAsJsonTypeInfo.class);
+    assertThat(bean.getTypeInfoSetter().getGeneralValue()).isEqualTo("General");
+    assertThat(((ConcreteStoredAsJsonTypeInfo) bean.getTypeInfoSetter()).getConcreteValue())
+        .isEqualTo("internal");
   }
 }

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonBean.java
@@ -29,6 +29,16 @@ public class StoredAsJsonBean {
   @StoredAsJson
   private JsonNode jsonNodeField;
 
+  @StoredAsJson
+  private Optional<StoredAsJsonTypeInfoBean> optionalTypeInfoField;
+  private Optional<StoredAsJsonTypeInfoBean> optionalTypeInfoGetter;
+  private Optional<StoredAsJsonTypeInfoBean> optionalTypeInfoSetter;
+
+  @StoredAsJson
+  private StoredAsJsonTypeInfoBean typeInfoField;
+  private StoredAsJsonTypeInfoBean typeInfoGetter;
+  private StoredAsJsonTypeInfoBean typeInfoSetter;
+
   public InnerBean getAnnotatedField() {
     return annotatedField;
   }
@@ -132,5 +142,57 @@ public class StoredAsJsonBean {
   public StoredAsJsonBean setJsonNodeField(JsonNode jsonNodeField) {
     this.jsonNodeField = jsonNodeField;
     return this;
+  }
+
+  public Optional<StoredAsJsonTypeInfoBean> getOptionalTypeInfoField() {
+    return optionalTypeInfoField;
+  }
+
+  public void setOptionalTypeInfoField(Optional<StoredAsJsonTypeInfoBean> optionalTypeInfoField) {
+    this.optionalTypeInfoField = optionalTypeInfoField;
+  }
+
+  @StoredAsJson
+  public Optional<StoredAsJsonTypeInfoBean> getOptionalTypeInfoGetter() {
+    return optionalTypeInfoGetter;
+  }
+
+  public void setOptionalTypeInfoGetter(Optional<StoredAsJsonTypeInfoBean> optionalTypeInfoGetter) {
+    this.optionalTypeInfoGetter = optionalTypeInfoGetter;
+  }
+
+  public Optional<StoredAsJsonTypeInfoBean> getOptionalTypeInfoSetter() {
+    return optionalTypeInfoSetter;
+  }
+
+  @StoredAsJson
+  public void setOptionalTypeInfoSetter(Optional<StoredAsJsonTypeInfoBean> optionalTypeInfoSetter) {
+    this.optionalTypeInfoSetter = optionalTypeInfoSetter;
+  }
+
+  public StoredAsJsonTypeInfoBean getTypeInfoField() {
+    return typeInfoField;
+  }
+
+  public void setTypeInfoField(StoredAsJsonTypeInfoBean typeInfoField) {
+    this.typeInfoField = typeInfoField;
+  }
+
+  @StoredAsJson
+  public StoredAsJsonTypeInfoBean getTypeInfoGetter() {
+    return typeInfoGetter;
+  }
+
+  public void setTypeInfoGetter(StoredAsJsonTypeInfoBean typeInfoGetter) {
+    this.typeInfoGetter = typeInfoGetter;
+  }
+
+  public StoredAsJsonTypeInfoBean getTypeInfoSetter() {
+    return typeInfoSetter;
+  }
+
+  @StoredAsJson
+  public void setTypeInfoSetter(StoredAsJsonTypeInfoBean typeInfoSetter) {
+    this.typeInfoSetter = typeInfoSetter;
   }
 }

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonTypeInfoBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonTypeInfoBean.java
@@ -1,0 +1,44 @@
+package com.hubspot.rosetta.beans;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.hubspot.rosetta.beans.StoredAsJsonTypeInfoBean.ConcreteStoredAsJsonTypeInfo;
+
+@JsonTypeInfo(use = Id.NAME, include = As.EXISTING_PROPERTY, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ConcreteStoredAsJsonTypeInfo.class, name = "concrete")
+})
+public interface StoredAsJsonTypeInfoBean {
+
+  String getType();
+  String getGeneralValue();
+
+  class ConcreteStoredAsJsonTypeInfo implements StoredAsJsonTypeInfoBean {
+    private String generalValue;
+    private String concreteValue;
+
+    @Override
+    public String getType() {
+      return "concrete";
+    }
+
+    @Override
+    public String getGeneralValue() {
+      return generalValue;
+    }
+
+    public void setGeneralValue(String generalValue) {
+      this.generalValue = generalValue;
+    }
+
+    public String getConcreteValue() {
+      return concreteValue;
+    }
+
+    public void setConcreteValue(String concreteValue) {
+      this.concreteValue = concreteValue;
+    }
+  }
+}


### PR DESCRIPTION
…ypeInfo` if the field is `Optional`, but not if it is not (`Optional`)

Note, this FAILS