### PR TITLE
Add test for deserializing inaccessible stored as json fields

### DIFF
--- a/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/StoredAsJsonTest.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/StoredAsJsonTest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.Optional;
 import com.hubspot.rosetta.Rosetta;
+import com.hubspot.rosetta.beans.InaccessibleStoredAsJsonBean;
 import com.hubspot.rosetta.beans.InnerBean;
 import com.hubspot.rosetta.beans.NestedStoredAsJsonBean;
 import com.hubspot.rosetta.beans.NullPolymorphicBean;
@@ -602,5 +603,14 @@ public class StoredAsJsonTest {
     JsonNode node = Rosetta.getMapper().valueToTree(bean);
     assertThat(node.get("annotatedField")).isNotNull();
     assertThat(node.get("annotatedField").isNull()).isTrue();
+  }
+
+  @Test
+  public void testDeserizalizeInaccessibleStoredAsJsonBean() throws Exception {
+    String json = "{\"fieldBean\":\"{\\\"id\\\":1}\"}";
+    InaccessibleStoredAsJsonBean deserialized =
+        Rosetta.getMapper().readValue(json, InaccessibleStoredAsJsonBean.class);
+    assertThat(deserialized)
+        .hasFieldOrPropertyWithValue("fieldBean.id", 1);
   }
 }

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/InaccessibleStoredAsJsonBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/InaccessibleStoredAsJsonBean.java
@@ -1,0 +1,28 @@
+package com.hubspot.rosetta.beans;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hubspot.rosetta.annotations.StoredAsJson;
+
+public class InaccessibleStoredAsJsonBean {
+  // No getter or @JsonProperty
+  @StoredAsJson
+  private final FieldBean fieldBean;
+
+  @JsonCreator
+  public InaccessibleStoredAsJsonBean(
+      @JsonProperty("fieldBean") FieldBean fieldBean
+  ) {
+    this.fieldBean = fieldBean;
+  }
+
+  public static class FieldBean {
+    @JsonProperty
+    private final int id;
+
+    @JsonCreator
+    public FieldBean(@JsonProperty("name") int id) {
+      this.id = id;
+    }
+  }
+}

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/InaccessibleStoredAsJsonBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/InaccessibleStoredAsJsonBean.java
@@ -21,7 +21,7 @@ public class InaccessibleStoredAsJsonBean {
     private final int id;
 
     @JsonCreator
-    public FieldBean(@JsonProperty("name") int id) {
+    public FieldBean(@JsonProperty("id") int id) {
       this.id = id;
     }
   }


### PR DESCRIPTION
This tests passes on Jackson 2.7.7 and fails on 2.9.9. I wasn't able to actually get the property to appear in the serialized output on either version, so I have no idea how this is working in the places it appears internally.

@jhaber @kmclarnon 