### PR TITLE
Add @RosettaIgnore

### DIFF
--- a/RosettaAnnotations/src/main/java/com/hubspot/rosetta/annotations/RosettaIgnore.java
+++ b/RosettaAnnotations/src/main/java/com/hubspot/rosetta/annotations/RosettaIgnore.java
@@ -1,0 +1,17 @@
+package com.hubspot.rosetta.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Like @JsonIgnore only limited to Rosetta mapping/binding
+ *
+ * If you want Rosetta to not include a certain element when serializing,
+ * you can use this annotation.
+ */
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RosettaIgnore {
+}

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
@@ -11,11 +11,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 import com.hubspot.rosetta.annotations.RosettaCreator;
 import com.hubspot.rosetta.annotations.RosettaDeserialize;
+import com.hubspot.rosetta.annotations.RosettaIgnore;
 import com.hubspot.rosetta.annotations.RosettaNaming;
 import com.hubspot.rosetta.annotations.RosettaProperty;
 import com.hubspot.rosetta.annotations.RosettaSerialize;
@@ -131,6 +133,11 @@ public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
   @Override
   public Value findPropertyInclusion(Annotated a) {
     return Value.construct(Include.ALWAYS, Include.ALWAYS);
+  }
+
+  @Override
+  public boolean hasIgnoreMarker(AnnotatedMember m) {
+    return m.hasAnnotation(RosettaIgnore.class);
   }
 
   @Override

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/RosettaIgnoreTest.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/RosettaIgnoreTest.java
@@ -1,0 +1,147 @@
+package com.hubspot.rosetta.annotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.hubspot.rosetta.Rosetta;
+
+public class RosettaIgnoreTest {
+  private static final String JSON = JsonNodeFactory.instance
+      .objectNode()
+      .put("stringProperty", "value")
+      .toString();
+  private static final String JSON_WITH_IGNORED = JsonNodeFactory.instance
+      .objectNode()
+      .put("stringProperty", "value")
+      .put("ignoredProperty", "ignored")
+      .toString();
+
+  @Test
+  public void itIgnoresMethodsWhenSerializing() throws JsonProcessingException {
+    IgnoreMethodBean bean = new IgnoreMethodBean();
+    assertThat(Rosetta.getMapper().writeValueAsString(bean))
+        .isEqualTo(JSON);
+  }
+
+  @Test
+  public void itIgnoresFieldsWhenSerializing() throws JsonProcessingException {
+    IgnoreFieldBean bean = new IgnoreFieldBean();
+    assertThat(Rosetta.getMapper().writeValueAsString(bean))
+        .isEqualTo(JSON);
+  }
+
+  @Test
+  public void itIgnoresIdenticallyNamedProperties() throws JsonProcessingException {
+    DuplicatePropertiesBean bean = new DuplicatePropertiesBean();
+    assertThat(Rosetta.getMapper().writeValueAsString(bean))
+        .isEqualTo(JSON);
+  }
+
+  @Test
+  public void itIgnoresMethodsWhenDeserializing() throws IOException {
+    IgnoreFieldMethodSetterBean bean = Rosetta.getMapper()
+        .readValue(JSON_WITH_IGNORED, IgnoreFieldMethodSetterBean.class);
+    assertThat(bean).isNotNull();
+    assertThat(bean.stringProperty).isEqualTo("value");
+    assertThat(bean.ignoredProperty).isNull();
+  }
+
+  @Test
+  public void itIgnoresFieldsWhenDeserializing() throws IOException {
+    IgnoreFieldSetterBean bean = Rosetta.getMapper()
+        .readValue(JSON_WITH_IGNORED, IgnoreFieldSetterBean.class);
+    assertThat(bean).isNotNull();
+    assertThat(bean.stringProperty).isEqualTo("value");
+    assertThat(bean.ignoredProperty).isNull();
+  }
+
+  @Test
+  public void itIgnoresConstructorsWhenDeserializing() throws IOException {
+    IgnoreConstructorBean bean = Rosetta.getMapper()
+        .readValue(JSON_WITH_IGNORED, IgnoreConstructorBean.class);
+    assertThat(bean).isNotNull();
+    assertThat(bean.stringProperty).isEqualTo("value");
+    assertThat(bean.ignoredProperty).isNull();
+  }
+
+  private static class IgnoreMethodBean {
+
+    public String getStringProperty() {
+      return "value";
+    }
+
+    @RosettaIgnore
+    public String getIgnoredProperty() {
+      return "ignored";
+    }
+  }
+
+  private static class IgnoreFieldBean {
+    @JsonProperty
+    private final String stringProperty = "value";
+
+    @RosettaIgnore
+    @JsonProperty
+    private final String ignoredProperty = "ignored";
+  }
+
+  private static class DuplicatePropertiesBean {
+    @RosettaProperty("stringProperty")
+    private final String includedProperty = "value";
+
+    @RosettaIgnore
+    @JsonProperty("stringProperty")
+    private final String ignoredProperty = "value2";
+  }
+
+  private static class IgnoreFieldMethodSetterBean {
+    private String stringProperty;
+    private String ignoredProperty;
+
+    public void setStringProperty(String stringProperty) {
+      this.stringProperty = stringProperty;
+    }
+
+    @RosettaIgnore
+    public void setIgnoredProperty(String ignoredProperty) {
+      this.ignoredProperty = ignoredProperty;
+    }
+  }
+
+  private static class IgnoreFieldSetterBean {
+    @JsonProperty
+    private String stringProperty;
+
+    @JsonProperty
+    @RosettaIgnore
+    private String ignoredProperty;
+  }
+
+  private static class IgnoreConstructorBean {
+    @JsonProperty
+    private String stringProperty;
+
+    @JsonProperty
+    @RosettaIgnore
+    private String ignoredProperty;
+
+    IgnoreConstructorBean() {}
+
+    @JsonCreator
+    @RosettaIgnore
+    IgnoreConstructorBean(
+        @JsonProperty("stringProperty") String stringProperty,
+        @JsonProperty("ignoredProperty") String ignoredProperty
+    ) {
+      this.stringProperty = stringProperty;
+      this.ignoredProperty = ignoredProperty;
+    }
+  }
+}


### PR DESCRIPTION
Under Jackson 2.12 (though I'd guess this change came in 2.10), duplicate field names in a bean will cause serialization to fail. I believe that it would previously simply overwrite duplicates as it encountered them, meaning that the property sources appearing later in a file would win out. Because we have code in which normal properties are redefined with `@RosettaProperty`, we need to add `@RosettaIgnore` in order to hide certain getters / setters from the rosetta mapper.

@jhaber @kmclarnon @Xcelled @snommit-mit 