### PR TITLE
Support ignoring @JsonValue

### DIFF
--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
@@ -139,6 +139,16 @@ public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
   }
 
   @Override
+  public Boolean hasAsValue(Annotated a) {
+    if (a.hasAnnotation(RosettaIgnore.class)) {
+      // The super method can return null, so we can't use && here
+      return false;
+    } else {
+      return super.hasAsValue(a);
+    }
+  }
+
+  @Override
   public Version version() {
     return Version.unknownVersion();
   }

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/RosettaIgnoreTest.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/RosettaIgnoreTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.hubspot.rosetta.Rosetta;
@@ -69,6 +70,13 @@ public class RosettaIgnoreTest {
     assertThat(bean).isNotNull();
     assertThat(bean.stringProperty).isEqualTo("value");
     assertThat(bean.ignoredProperty).isNull();
+  }
+
+  @Test
+  public void itIgnoresJsonValueWhenSerializing() throws JsonProcessingException {
+    IgnoreJsonValueBean bean = new IgnoreJsonValueBean();
+    assertThat(Rosetta.getMapper().writeValueAsString(bean))
+        .isEqualTo(Integer.toString(bean.getId()));
   }
 
   private static class IgnoreMethodBean {
@@ -142,6 +150,20 @@ public class RosettaIgnoreTest {
     ) {
       this.stringProperty = stringProperty;
       this.ignoredProperty = ignoredProperty;
+    }
+  }
+
+  private class IgnoreJsonValueBean {
+
+    @RosettaValue
+    public int getId() {
+      return 1;
+    }
+
+    @JsonValue
+    @RosettaIgnore
+    public String getCode() {
+      return "a";
     }
   }
 }


### PR DESCRIPTION
The current implementation doesn't respect `@RosettaIgnore` on `@JsonValue` methods.

@jhaber @kmclarnon @Xcelled @snommit-mit 