### PR TITLE
Document how to override ObjectMapper when using JDBI3

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -211,3 +211,15 @@ level, you would do the following while setting up your `DBI`:
 To set at the handle or statement level would look similar:  
 `new RosettaObjectMapperOverride(myOtherObjectMapper).override(handle);`  
 `new RosettaObjectMapperOverride(myOtherOtherObjectMapper).override(query);`
+
+### JDBI3
+
+`RosettaObjectMapperOverride` is no longer available when using Jdbi 3.  To override the `ObjectMapper` for all Jdbi instances
+when you are setting up your `JDBI`:
+
+```java
+jdbi.getConfig()
+        .get(RosettaObjectMapper.class)
+        .setObjectMapper(myObjectMapper);
+```
+


### PR DESCRIPTION
I'm using JDBI3 with Rosetta and I had trouble figuring out how to override the default `ObjectMapper`.  There were only instructions for how to do this for JDBI2 but not JDBI3, so I figure adding this to advanced features could save folks some time.  