### PR TITLE
Add RosettaImmutables module

### DIFF
--- a/RosettaImmutables/pom.xml
+++ b/RosettaImmutables/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.hubspot.rosetta</groupId>
+    <artifactId>Rosetta</artifactId>
+    <version>3.11.11-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>RosettaImmutables</artifactId>
+
+  <properties>
+    <hubspot.module.type>CORE</hubspot.module.type>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.hubspot.immutables</groupId>
+        <artifactId>hubspot-style</artifactId>
+        <version>1.3-SNAPSHOT</version>
+        <!-- TODO - do we actually want to do this? -->
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.hubspot.immutables</groupId>
+        <artifactId>immutables-exceptions</artifactId>
+        <version>1.3-SNAPSHOT</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.hubspot.rosetta</groupId>
+      <artifactId>RosettaCore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.hubspot.rosetta</groupId>
+      <artifactId>RosettaAnnotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.hubspot.immutables</groupId>
+      <artifactId>hubspot-style</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/RosettaImmutables/pom.xml
+++ b/RosettaImmutables/pom.xml
@@ -20,7 +20,6 @@
         <groupId>com.hubspot.immutables</groupId>
         <artifactId>hubspot-style</artifactId>
         <version>1.3-SNAPSHOT</version>
-        <!-- TODO - do we actually want to do this? -->
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>

--- a/RosettaImmutables/pom.xml
+++ b/RosettaImmutables/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>com.hubspot.immutables</groupId>
         <artifactId>hubspot-style</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -30,7 +30,7 @@
       <dependency>
         <groupId>com.hubspot.immutables</groupId>
         <artifactId>immutables-exceptions</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/ContextualHelper.java
+++ b/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/ContextualHelper.java
@@ -1,0 +1,39 @@
+package com.hubspot.rosetta.immutables;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.hubspot.immutables.utils.WireSafeEnum;
+
+class ContextualHelper {
+
+  private ContextualHelper() {
+    throw new AssertionError();
+  }
+
+  interface ExceptionHandler {
+    void report(String msg) throws JsonMappingException;
+  }
+
+  public static <T> T createContextual(Supplier<JavaType> typeSupplier,
+                                       Function<Class<?>, T> contextualFactory,
+                                       ExceptionHandler exceptionHandler) throws JsonMappingException {
+    JavaType contextualType = typeSupplier.get();
+    if (contextualType == null || !contextualType.hasRawClass(WireSafeEnum.class)) {
+      exceptionHandler.report("Can not handle contextualType: " + contextualType);
+    } else {
+      JavaType[] typeParameters = contextualType.findTypeParameters(WireSafeEnum.class);
+      if (typeParameters.length != 1) {
+        exceptionHandler.report("Can not discover enum type for: " + contextualType);
+      } else if (!typeParameters[0].isEnumType()) {
+        exceptionHandler.report("Can not handle non-enum type: " + typeParameters[0].getRawClass());
+      } else {
+        return contextualFactory.apply(typeParameters[0].getRawClass());
+      }
+    }
+
+    return null;
+  }
+}

--- a/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaAwareWireSafeEnumDeserializer.java
+++ b/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaAwareWireSafeEnumDeserializer.java
@@ -1,0 +1,63 @@
+package com.hubspot.rosetta.immutables;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.hubspot.immutables.utils.WireSafeEnum;
+
+public class RosettaAwareWireSafeEnumDeserializer extends JsonDeserializer<WireSafeEnum<?>> implements ContextualDeserializer {
+  private static final Map<Class<?>, JsonDeserializer<WireSafeEnum<?>>> DESERIALIZER_CACHE = new ConcurrentHashMap<>();
+
+  @Override
+  public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) throws JsonMappingException {
+    JavaType contextualType = ctxt.getContextualType();
+    if (contextualType == null || !contextualType.hasRawClass(WireSafeEnum.class)) {
+      throw ctxt.mappingException("Can not handle contextualType: " + contextualType);
+    } else {
+      JavaType[] typeParameters = contextualType.findTypeParameters(WireSafeEnum.class);
+      if (typeParameters.length != 1) {
+        throw ctxt.mappingException("Can not discover enum type for: " + contextualType);
+      } else if (!typeParameters[0].isEnumType()) {
+        throw ctxt.mappingException("Can not handle non-enum type: " + typeParameters[0].getRawClass());
+      } else {
+        return deserializerFor(typeParameters[0].getRawClass());
+      }
+    }
+  }
+
+  @Override
+  public WireSafeEnum<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    throw ctxt.mappingException("Expected createContextual to be called");
+  }
+
+  private static <T extends Enum<T>> JsonDeserializer<?> deserializerFor(Class<?> rawType) {
+    return DESERIALIZER_CACHE.computeIfAbsent(rawType, ignored -> {
+      @SuppressWarnings("unchecked")
+      Class<T> enumType = (Class<T>) rawType;
+      return newDeserializer(enumType);
+    });
+  }
+
+  private static <T extends Enum<T>> JsonDeserializer<WireSafeEnum<?>> newDeserializer(Class<T> enumType) {
+    return new JsonDeserializer<WireSafeEnum<?>>() {
+
+      @Override
+      public WireSafeEnum<T> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        try {
+          return WireSafeEnum.of(p.getCodec().readValue(p, enumType));
+        } catch (IOException e) {
+          // TODO - better messaging
+          throw ctxt.mappingException("Could not deserialize wiresafe enum");
+        }
+      }
+    };
+  }
+}

--- a/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaAwareWireSafeEnumDeserializer.java
+++ b/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaAwareWireSafeEnumDeserializer.java
@@ -51,12 +51,14 @@ public class RosettaAwareWireSafeEnumDeserializer extends JsonDeserializer<WireS
 
       @Override
       public WireSafeEnum<T> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        T value;
         try {
-          return WireSafeEnum.of(p.getCodec().readValue(p, enumType));
+          value = p.getCodec().readValue(p, enumType);
         } catch (IOException e) {
-          // TODO - better messaging
-          throw ctxt.mappingException("Could not deserialize wiresafe enum");
+          throw new IllegalStateException("Invalid value for enum type: " + enumType.getTypeName(), e);
         }
+
+        return WireSafeEnum.of(value);
       }
     };
   }

--- a/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaAwareWireSafeEnumSerializer.java
+++ b/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaAwareWireSafeEnumSerializer.java
@@ -1,0 +1,68 @@
+package com.hubspot.rosetta.immutables;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+import com.hubspot.immutables.utils.WireSafeEnum;
+
+public class RosettaAwareWireSafeEnumSerializer extends JsonSerializer<WireSafeEnum<?>> implements ContextualSerializer {
+  private static final Map<Class<?>, JsonSerializer<WireSafeEnum<?>>> SERIALIZER_CACHE = new ConcurrentHashMap<>();
+
+  @Override
+  public JsonSerializer<?> createContextual(SerializerProvider prov, BeanProperty property) throws JsonMappingException {
+    JavaType contextualType = property.getType();
+    if (contextualType != null && contextualType.hasRawClass(WireSafeEnum.class)) {
+      JavaType[] typeParameters = contextualType.findTypeParameters(WireSafeEnum.class);
+      if (typeParameters.length != 1) {
+        prov.reportMappingProblem("Can not discover enum type for: " + contextualType);
+      } else if (!typeParameters[0].isEnumType()) {
+        prov.reportMappingProblem("Can not handle non-enum type: " + typeParameters[0].getRawClass());
+      } else {
+        return serializerFor(typeParameters[0].getRawClass());
+      }
+    } else {
+      prov.reportMappingProblem("Can not handle contextualType: " + contextualType);
+    }
+
+    return null;
+  }
+
+  @Override
+  public void serialize(WireSafeEnum value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    serializers.reportMappingProblem("Expected createContextual to be called");
+  }
+
+  private static <T extends Enum<T>> JsonSerializer<?> serializerFor(Class<?> rawType) {
+    return SERIALIZER_CACHE.computeIfAbsent(rawType, ignored -> {
+      @SuppressWarnings("unchecked")
+      Class<T> enumType = (Class<T>) rawType;
+      return newDeserializer(enumType);
+    });
+  }
+
+  private static <T extends Enum<T>> JsonSerializer<WireSafeEnum<?>> newDeserializer(Class<T> enumType) {
+    return new JsonSerializer<WireSafeEnum<?>>() {
+      @Override
+      public void serialize(WireSafeEnum<?> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        Optional<? extends Enum<?>> enumValue = value.asEnum();
+        if (enumValue.isPresent()) {
+          serializers.defaultSerializeValue(enumValue.get(), gen);
+        } else {
+          serializers.reportMappingProblem(
+              "Cannot serialize WireSafeEnum<%s> with unknown enum value: %s",
+              enumType.getSimpleName(),
+              value.asString());
+        }
+      }
+    };
+  }
+}

--- a/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaAwareWireSafeEnumSerializer.java
+++ b/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaAwareWireSafeEnumSerializer.java
@@ -7,7 +7,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -19,21 +18,10 @@ public class RosettaAwareWireSafeEnumSerializer extends JsonSerializer<WireSafeE
 
   @Override
   public JsonSerializer<?> createContextual(SerializerProvider prov, BeanProperty property) throws JsonMappingException {
-    JavaType contextualType = property.getType();
-    if (contextualType != null && contextualType.hasRawClass(WireSafeEnum.class)) {
-      JavaType[] typeParameters = contextualType.findTypeParameters(WireSafeEnum.class);
-      if (typeParameters.length != 1) {
-        prov.reportMappingProblem("Can not discover enum type for: " + contextualType);
-      } else if (!typeParameters[0].isEnumType()) {
-        prov.reportMappingProblem("Can not handle non-enum type: " + typeParameters[0].getRawClass());
-      } else {
-        return serializerFor(typeParameters[0].getRawClass());
-      }
-    } else {
-      prov.reportMappingProblem("Can not handle contextualType: " + contextualType);
-    }
-
-    return null;
+    return ContextualHelper.createContextual(
+        property::getType,
+        RosettaAwareWireSafeEnumSerializer::serializerFor,
+        prov::reportMappingProblem);
   }
 
   @Override

--- a/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaImmutablesModule.java
+++ b/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaImmutablesModule.java
@@ -1,0 +1,24 @@
+package com.hubspot.rosetta.immutables;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.Module;
+import com.hubspot.immutables.utils.WireSafeEnum;
+
+public class RosettaImmutablesModule extends Module {
+
+  @Override
+  public String getModuleName() {
+    return getClass().getName();
+  }
+
+  @Override
+  public Version version() {
+    return Version.unknownVersion();
+  }
+
+  @Override
+  public void setupModule(SetupContext context) {
+    // use this mixin to override @JsonSerialize/@JsonDeserialize on WireSafeEnum
+    context.setMixInAnnotations(WireSafeEnum.class, WireSafeEnumMixin.class);
+  }
+}

--- a/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/WireSafeEnumMixin.java
+++ b/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/WireSafeEnumMixin.java
@@ -1,0 +1,9 @@
+package com.hubspot.rosetta.immutables;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize(using = RosettaAwareWireSafeEnumSerializer.class)
+@JsonDeserialize(using = RosettaAwareWireSafeEnumDeserializer.class)
+public class WireSafeEnumMixin {
+}

--- a/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/WireSafeEnumTest.java
+++ b/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/WireSafeEnumTest.java
@@ -1,0 +1,54 @@
+package com.hubspot.rosetta.immutables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.immutables.utils.WireSafeEnum;
+import com.hubspot.rosetta.Rosetta;
+import com.hubspot.rosetta.immutables.beans.CustomEnum;
+import com.hubspot.rosetta.immutables.beans.SimpleEnum;
+import com.hubspot.rosetta.immutables.beans.WireSafeBean;
+
+public class WireSafeEnumTest {
+  private static final ObjectMapper MAPPER = Rosetta
+      .getMapper()
+      .copy()
+      .registerModule(new RosettaImmutablesModule());
+
+  @Test
+  public void itCanSerializeBeanWithWireSafeField() {
+    WireSafeBean bean = new WireSafeBean();
+    bean.setSimple(WireSafeEnum.of(SimpleEnum.ONE));
+    bean.setCustom(WireSafeEnum.of(CustomEnum.ONE));
+
+    assertThat(serialize(bean)).isEqualTo(asNode("{\"simple\": \"ONE\", \"custom\": 1}"));
+  }
+
+  @Test
+  public void itCanDeserializeBeanWithWireSafeField() {
+    WireSafeBean bean = new WireSafeBean();
+    bean.setSimple(WireSafeEnum.of(SimpleEnum.ONE));
+    bean.setCustom(WireSafeEnum.of(CustomEnum.ONE));
+
+    assertThat(deserialize("{\"simple\": \"ONE\", \"custom\": 1}", WireSafeBean.class)).isEqualTo(bean);
+  }
+
+  private JsonNode asNode(String value) {
+    return deserialize(value, JsonNode.class);
+  }
+
+  private <T> T deserialize(String value, Class<T> klass) {
+    try {
+      return MAPPER.readValue(value, klass);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private JsonNode serialize(Object o) {
+    return MAPPER.valueToTree(o);
+  }
+}

--- a/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/WireSafeEnumTest.java
+++ b/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/WireSafeEnumTest.java
@@ -31,9 +31,9 @@ public class WireSafeEnumTest {
   public void itCanDeserializeBeanWithWireSafeField() {
     WireSafeBean bean = new WireSafeBean();
     bean.setSimple(WireSafeEnum.of(SimpleEnum.ONE));
-    bean.setCustom(WireSafeEnum.of(CustomEnum.ONE));
+    bean.setCustom(WireSafeEnum.of(CustomEnum.TWO));
 
-    assertThat(deserialize("{\"simple\": \"ONE\", \"custom\": 1}", WireSafeBean.class)).isEqualTo(bean);
+    assertThat(deserialize("{\"simple\": \"ONE\", \"custom\": 2}", WireSafeBean.class)).isEqualTo(bean);
   }
 
   private JsonNode asNode(String value) {

--- a/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/beans/CustomEnum.java
+++ b/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/beans/CustomEnum.java
@@ -1,0 +1,37 @@
+package com.hubspot.rosetta.immutables.beans;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.collect.Maps;
+import com.hubspot.rosetta.annotations.RosettaCreator;
+import com.hubspot.rosetta.annotations.RosettaValue;
+
+public enum CustomEnum {
+  ONE(1),
+  TWO(2),
+  ;
+
+  private static final Map<Integer, CustomEnum> LOOKUP =
+      Maps.uniqueIndex(
+          Arrays.asList(CustomEnum.values()),
+          CustomEnum::getValue);
+
+  private final int value;
+
+  CustomEnum(int value) {
+    this.value = value;
+  }
+
+  @RosettaValue
+  public int getValue() {
+    return value;
+  }
+
+  @RosettaCreator
+  public static CustomEnum from(int value) {
+    return Optional.ofNullable(LOOKUP.get(value))
+        .orElseThrow(() -> new IllegalArgumentException("No enum for value: " + value));
+  }
+}

--- a/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/beans/SimpleEnum.java
+++ b/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/beans/SimpleEnum.java
@@ -1,0 +1,6 @@
+package com.hubspot.rosetta.immutables.beans;
+
+public enum SimpleEnum {
+  ONE,
+  TWO
+}

--- a/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/beans/WireSafeBean.java
+++ b/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/beans/WireSafeBean.java
@@ -1,0 +1,54 @@
+package com.hubspot.rosetta.immutables.beans;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.hubspot.immutables.utils.WireSafeEnum;
+
+public class WireSafeBean {
+    private WireSafeEnum<SimpleEnum> simple;
+    private WireSafeEnum<CustomEnum> custom;
+
+    public WireSafeEnum<SimpleEnum> getSimple() {
+      return simple;
+    }
+
+  public WireSafeEnum<CustomEnum> getCustom() {
+    return custom;
+  }
+
+  public void setSimple(WireSafeEnum<SimpleEnum> simple) {
+    this.simple = simple;
+  }
+
+  public void setCustom(WireSafeEnum<CustomEnum> custom) {
+    this.custom = custom;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects
+        .toStringHelper(WireSafeBean.class)
+        .add("simple", simple)
+        .add("custom", custom).toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    WireSafeBean bean = (WireSafeBean) o;
+    return Objects.equal(simple, bean.simple) &&
+        Objects.equal(custom, bean.custom);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(simple, custom);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <module>RosettaCore</module>
     <module>RosettaJdbi</module>
     <module>RosettaJdbi3</module>
+    <module>RosettaImmutables</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
This PR adds Rosetta support for things from [hubspot-immutables](https://github.com/HubSpot/hubspot-immutables), specifically `WireSafeEnum`.  A module for the rosetta object mapper is provided to override the serialization behavior of `WireSafeEnum` to support enums that utilize `@RosettaValue` and/or `@RosettaCreator`.

The error messaging still needs work but I wanted to get some eyes on this before continuing in this direction.

@stevegutz @jhaber @Xcelled @snommit-mit 