### PR TITLE
Fix non-determininstic test itBindsStoredAsJsonBeanCorrectly()

### DIFF
--- a/RosettaCore/src/test/java/com/hubspot/rosetta/RosettaBinderTest.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/RosettaBinderTest.java
@@ -2,6 +2,7 @@ package com.hubspot.rosetta;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -84,52 +85,51 @@ public class RosettaBinderTest {
     bean.setTypeInfoGetter(concrete);
     bean.setTypeInfoSetter(concrete);
 
-    ObjectMapper mapper = new ObjectMapper();
-    JsonNode typedJson = mapper.readTree("{\"generalValue\":\"general\",\"concreteValue\":\"concrete\",\"type\":\"concrete\"}");
-    JsonNode json = mapper.readTree("{\"stringProperty\":\"value\"}");
-    List<Byte> bytes = toList(mapper.writeValueAsString(json).getBytes(StandardCharsets.UTF_8));
+    String json = "{\"stringProperty\":\"value\"}";
+    String typedJson = "{\"generalValue\":\"general\",\"concreteValue\":\"concrete\",\"type\":\"concrete\"}";
+    List<Byte> bytes = toList(json.getBytes(StandardCharsets.UTF_8));
 
-    Map<String, Object> BeanMap = bind(bean);
-    assertThat(mapper.readTree(BeanMap.get("annotatedField").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("annotatedGetter").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("annotatedSetter").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("annotatedFieldWithDefault").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("annotatedGetterWithDefault").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("annotatedSetterWithDefault").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("optionalField").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("optionalGetter").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("optionalSetter").toString()).equals(json)).isTrue();
-    assertThat(BeanMap.get("binaryField")).isEqualTo(bytes);
-    assertThat(BeanMap.get("binaryFieldWithDefault")).isEqualTo(bytes);
-    assertThat(mapper.readTree(BeanMap.get("jsonNodeField").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("optionalTypeInfoField").toString()).equals(typedJson)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("optionalTypeInfoGetter").toString()).equals(typedJson)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("optionalTypeInfoSetter").toString()).equals(typedJson)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("typeInfoField").toString()).equals(typedJson)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("typeInfoGetter").toString()).equals(typedJson)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("typeInfoSetter").toString()).equals(typedJson)).isTrue();
-    assertThat(BeanMap.keySet().size()).isEqualTo(18);
+    Map<String, Object> beanMap = bind(bean);
+    compareField(beanMap, "annotatedField", json);
+    compareField(beanMap, "annotatedGetter", json);
+    compareField(beanMap, "annotatedSetter", json);
+    compareField(beanMap, "annotatedFieldWithDefault", json);
+    compareField(beanMap, "annotatedGetterWithDefault", json);
+    compareField(beanMap, "annotatedSetterWithDefault", json);
+    compareField(beanMap, "optionalField", json);
+    compareField(beanMap, "optionalGetter", json);
+    compareField(beanMap, "optionalSetter", json);
+    assertThat(beanMap.get("binaryField")).isEqualTo(bytes);
+    assertThat(beanMap.get("binaryFieldWithDefault")).isEqualTo(bytes);
+    compareField(beanMap, "jsonNodeField", json);
+    compareField(beanMap, "optionalTypeInfoField", typedJson);
+    compareField(beanMap, "optionalTypeInfoGetter", typedJson);
+    compareField(beanMap, "optionalTypeInfoSetter", typedJson);
+    compareField(beanMap, "typeInfoField", typedJson);
+    compareField(beanMap, "typeInfoGetter", typedJson);
+    compareField(beanMap, "typeInfoSetter", typedJson);
+    assertThat(beanMap.keySet().size()).isEqualTo(18);
 
-    BeanMap = bindWithPrefix("prefix", bean);
-    assertThat(mapper.readTree(BeanMap.get("prefix.annotatedField").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.annotatedGetter").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.annotatedSetter").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.annotatedFieldWithDefault").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.annotatedGetterWithDefault").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.annotatedSetterWithDefault").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.optionalField").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.optionalGetter").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.optionalSetter").toString()).equals(json)).isTrue();
-    assertThat(BeanMap.get("prefix.binaryField")).isEqualTo(bytes);
-    assertThat(BeanMap.get("prefix.binaryFieldWithDefault")).isEqualTo(bytes);
-    assertThat(mapper.readTree(BeanMap.get("prefix.jsonNodeField").toString()).equals(json)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.optionalTypeInfoField").toString()).equals(typedJson)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.optionalTypeInfoGetter").toString()).equals(typedJson)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.optionalTypeInfoSetter").toString()).equals(typedJson)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.typeInfoField").toString()).equals(typedJson)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.typeInfoGetter").toString()).equals(typedJson)).isTrue();
-    assertThat(mapper.readTree(BeanMap.get("prefix.typeInfoSetter").toString()).equals(typedJson)).isTrue();
-    assertThat(BeanMap.keySet().size()).isEqualTo(18);
+    beanMap = bindWithPrefix("prefix", bean);
+    compareField(beanMap, "prefix.annotatedField", json);
+    compareField(beanMap, "prefix.annotatedGetter", json);
+    compareField(beanMap, "prefix.annotatedSetter", json);
+    compareField(beanMap, "prefix.annotatedFieldWithDefault", json);
+    compareField(beanMap, "prefix.annotatedGetterWithDefault", json);
+    compareField(beanMap, "prefix.annotatedSetterWithDefault", json);
+    compareField(beanMap, "prefix.optionalField", json);
+    compareField(beanMap, "prefix.optionalGetter", json);
+    compareField(beanMap, "prefix.optionalSetter", json);
+    assertThat(beanMap.get("prefix.binaryField")).isEqualTo(bytes);
+    assertThat(beanMap.get("prefix.binaryFieldWithDefault")).isEqualTo(bytes);
+    compareField(beanMap, "prefix.jsonNodeField", json);
+    compareField(beanMap, "prefix.optionalTypeInfoField", typedJson);
+    compareField(beanMap, "prefix.optionalTypeInfoGetter", typedJson);
+    compareField(beanMap, "prefix.optionalTypeInfoSetter", typedJson);
+    compareField(beanMap, "prefix.typeInfoField", typedJson);
+    compareField(beanMap, "prefix.typeInfoGetter", typedJson);
+    compareField(beanMap, "prefix.typeInfoSetter", typedJson);
+    assertThat(beanMap.keySet().size()).isEqualTo(18);
   }
 
   @Test
@@ -257,5 +257,17 @@ public class RosettaBinderTest {
     }
 
     return byteList;
+  }
+
+  private void compareField(Map<String, Object> beanMap, String fieldName, String expectedJson) {
+    ObjectMapper mapper = new ObjectMapper();
+    try {
+      JsonNode expectedJsonNode = mapper.readTree(expectedJson);
+      JsonNode actualJsonNode = mapper.readTree(beanMap.get(fieldName).toString());
+      assertThat(actualJsonNode).isEqualTo(expectedJsonNode);
+    } catch (IOException e) {
+      // Parsed string is not in valid JSON format
+      assert(false);
+    }
   }
 }

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/RosettaBinderTest.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/RosettaBinderTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.Optional;
 import com.hubspot.rosetta.RosettaBinder.Callback;
@@ -83,50 +84,52 @@ public class RosettaBinderTest {
     bean.setTypeInfoGetter(concrete);
     bean.setTypeInfoSetter(concrete);
 
-    String json = "{\"stringProperty\":\"value\"}";
-    String typedJson = "{\"generalValue\":\"general\",\"concreteValue\":\"concrete\",\"type\":\"concrete\"}";
-    List<Byte> bytes = toList(json.getBytes(StandardCharsets.UTF_8));
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode typedJson = mapper.readTree("{\"generalValue\":\"general\",\"concreteValue\":\"concrete\",\"type\":\"concrete\"}");
+    JsonNode json = mapper.readTree("{\"stringProperty\":\"value\"}");
+    List<Byte> bytes = toList(mapper.writeValueAsString(json).getBytes(StandardCharsets.UTF_8));
 
-    assertThat(bind(bean)).isEqualTo(map(
-            "annotatedField", json,
-            "annotatedGetter", json,
-            "annotatedSetter", json,
-            "annotatedFieldWithDefault", json,
-            "annotatedGetterWithDefault", json,
-            "annotatedSetterWithDefault", json,
-            "optionalField", json,
-            "optionalGetter", json,
-            "optionalSetter", json,
-            "binaryField", bytes,
-            "binaryFieldWithDefault", bytes,
-            "jsonNodeField", json,
-            "optionalTypeInfoField", typedJson,
-            "optionalTypeInfoGetter", typedJson,
-            "optionalTypeInfoSetter", typedJson,
-            "typeInfoField", typedJson,
-            "typeInfoGetter", typedJson,
-            "typeInfoSetter", typedJson
-    ));
-    assertThat(bindWithPrefix("prefix", bean)).isEqualTo(map(
-            "prefix.annotatedField", json,
-            "prefix.annotatedGetter", json,
-            "prefix.annotatedSetter", json,
-            "prefix.annotatedFieldWithDefault", json,
-            "prefix.annotatedGetterWithDefault", json,
-            "prefix.annotatedSetterWithDefault", json,
-            "prefix.optionalField", json,
-            "prefix.optionalGetter", json,
-            "prefix.optionalSetter", json,
-            "prefix.binaryField", bytes,
-            "prefix.binaryFieldWithDefault", bytes,
-            "prefix.jsonNodeField", json,
-            "prefix.optionalTypeInfoField", typedJson,
-            "prefix.optionalTypeInfoGetter", typedJson,
-            "prefix.optionalTypeInfoSetter", typedJson,
-            "prefix.typeInfoField", typedJson,
-            "prefix.typeInfoGetter", typedJson,
-            "prefix.typeInfoSetter", typedJson
-    ));
+    Map<String, Object> BeanMap = bind(bean);
+    assertThat(mapper.readTree(BeanMap.get("annotatedField").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("annotatedGetter").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("annotatedSetter").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("annotatedFieldWithDefault").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("annotatedGetterWithDefault").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("annotatedSetterWithDefault").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("optionalField").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("optionalGetter").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("optionalSetter").toString()).equals(json)).isTrue();
+    assertThat(BeanMap.get("binaryField")).isEqualTo(bytes);
+    assertThat(BeanMap.get("binaryFieldWithDefault")).isEqualTo(bytes);
+    assertThat(mapper.readTree(BeanMap.get("jsonNodeField").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("optionalTypeInfoField").toString()).equals(typedJson)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("optionalTypeInfoGetter").toString()).equals(typedJson)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("optionalTypeInfoSetter").toString()).equals(typedJson)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("typeInfoField").toString()).equals(typedJson)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("typeInfoGetter").toString()).equals(typedJson)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("typeInfoSetter").toString()).equals(typedJson)).isTrue();
+    assertThat(BeanMap.keySet().size()).isEqualTo(18);
+
+    BeanMap = bindWithPrefix("prefix", bean);
+    assertThat(mapper.readTree(BeanMap.get("prefix.annotatedField").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.annotatedGetter").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.annotatedSetter").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.annotatedFieldWithDefault").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.annotatedGetterWithDefault").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.annotatedSetterWithDefault").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.optionalField").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.optionalGetter").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.optionalSetter").toString()).equals(json)).isTrue();
+    assertThat(BeanMap.get("prefix.binaryField")).isEqualTo(bytes);
+    assertThat(BeanMap.get("prefix.binaryFieldWithDefault")).isEqualTo(bytes);
+    assertThat(mapper.readTree(BeanMap.get("prefix.jsonNodeField").toString()).equals(json)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.optionalTypeInfoField").toString()).equals(typedJson)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.optionalTypeInfoGetter").toString()).equals(typedJson)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.optionalTypeInfoSetter").toString()).equals(typedJson)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.typeInfoField").toString()).equals(typedJson)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.typeInfoGetter").toString()).equals(typedJson)).isTrue();
+    assertThat(mapper.readTree(BeanMap.get("prefix.typeInfoSetter").toString()).equals(typedJson)).isTrue();
+    assertThat(BeanMap.keySet().size()).isEqualTo(18);
   }
 
   @Test


### PR DESCRIPTION
Hi,

I am from the Software Testing research group at the University of Illinois. We want to inform that the test `com.hubspot.rosetta.RosettaBinderTest.itBindsStoredAsJsonBeanCorrectly()` is non deterministic. The non determinism has been discovered using the `NonDex` tool for catching non-deterministic/flaky tests (https://github.com/TestingResearchIllinois/NonDex).

You may reproduce the non deterministic behavior using the following steps:
1. Clone the repo and cd into it.
2. `mvn install -am -pl RosettaCore -DskipTests`
3. `mvn -pl RosettaCore test -Dtest=com.hubspot.rosetta.RosettaBinderTest#itBindsStoredAsJsonBeanCorrectly` - Confirm that the test passes as is.
4. `mvn -pl RosettaCore edu.illinois:nondex-maven-plugin:1.1.2:nondex -DnondexMode=ONE -Dtest=com.hubspot.rosetta.RosettaBinderTest#itBindsStoredAsJsonBeanCorrectly` - This will run the NonDex tool on the test. You will find the test fails.

Why is the test non-deterministic?
The non-determinism arises from the way JSON strings are compared. `bean` variable stores concrete into its member fields as it is using its member set functions. When `bind` is called on `bean`, it converts `concrete` into a JSON string. That conversion does not guarantee the order in which JSON object fields appear in the resulting JSON string, as shown by the NonDex plugin. This can result in string comparison of two JSON strings that differ only in the order in which their JSON fields appear. Since these JSON strings are compared as two normal strings, they will be considered unequal, causing the tests to fail. Currently, the tests pass based on the current implementation of that conversion, but its interface makes no guarantees on the order.

Proposed fix:
Comparing JSON strings as JSON objects instead of Java Strings can solve the problem because it will ignore the ordering of JSON fields when comparing two JSON strings. Implementing this functionality will take many lines of code, but luckily, this project already has `FasterXML Jackson` as one of its dependencies. We used their `JsonNode` and `ObjectMapper` class methods, which allow us to do the JSON comparison that we want.

If you would like, there are some more non-deterministic tests in this repository, for which I can open new PRs.