### PR TITLE
Support Lists of WireSafeEnums

### DIFF
--- a/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/ContextualHelper.java
+++ b/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/ContextualHelper.java
@@ -49,9 +49,10 @@ class ContextualHelper {
       return null;
     } else if (type.hasRawClass(WireSafeEnum.class)) {
       return type;
-    } else if (type.hasRawClass(Optional.class)
-        || type.hasRawClass(com.google.common.base.Optional.class)
-        || type.hasRawClass(List.class)
+    } else if (
+        type.hasRawClass(Optional.class) ||
+        type.hasRawClass(com.google.common.base.Optional.class) ||
+        type.hasRawClass(List.class)
     ) {
       return type.containedType(0);
     } else {

--- a/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/ContextualHelper.java
+++ b/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/ContextualHelper.java
@@ -1,5 +1,6 @@
 package com.hubspot.rosetta.immutables;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -48,7 +49,7 @@ class ContextualHelper {
       return null;
     } else if (type.hasRawClass(WireSafeEnum.class)) {
       return type;
-    } else if (type.hasRawClass(Optional.class) || type.hasRawClass(com.google.common.base.Optional.class)) {
+    } else if (type.hasRawClass(Optional.class) || type.hasRawClass(com.google.common.base.Optional.class) || type.hasRawClass(List.class)) {
       return type.containedType(0);
     } else {
       return null;

--- a/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/ContextualHelper.java
+++ b/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/ContextualHelper.java
@@ -49,7 +49,10 @@ class ContextualHelper {
       return null;
     } else if (type.hasRawClass(WireSafeEnum.class)) {
       return type;
-    } else if (type.hasRawClass(Optional.class) || type.hasRawClass(com.google.common.base.Optional.class) || type.hasRawClass(List.class)) {
+    } else if (type.hasRawClass(Optional.class)
+        || type.hasRawClass(com.google.common.base.Optional.class)
+        || type.hasRawClass(List.class)
+    ) {
       return type.containedType(0);
     } else {
       return null;

--- a/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/WireSafeEnumTest.java
+++ b/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/WireSafeEnumTest.java
@@ -2,6 +2,7 @@ package com.hubspot.rosetta.immutables;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -9,6 +10,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.collect.ImmutableList;
 import com.hubspot.immutables.utils.WireSafeEnum;
 import com.hubspot.rosetta.Rosetta;
 import com.hubspot.rosetta.immutables.beans.CustomEnum;
@@ -28,8 +30,10 @@ public class WireSafeEnumTest {
     bean.setCustom(WireSafeEnum.of(CustomEnum.ONE));
     bean.setSimpleMaybe(Optional.of(WireSafeEnum.of(SimpleEnum.TWO)));
     bean.setCustomMaybe(Optional.of(WireSafeEnum.of(CustomEnum.TWO)));
+    bean.setSimpleList(ImmutableList.of(WireSafeEnum.of(SimpleEnum.ONE), WireSafeEnum.of(SimpleEnum.TWO)));
+    bean.setCustomList(ImmutableList.of(WireSafeEnum.of(CustomEnum.ONE), WireSafeEnum.of(CustomEnum.TWO)));
 
-    assertThat(serialize(bean)).isEqualTo(asNode("{\"simple\": \"ONE\", \"custom\": 1, \"simpleMaybe\": \"TWO\", \"customMaybe\": 2}"));
+    assertThat(serialize(bean)).isEqualTo(asNode("{\"simple\": \"ONE\", \"custom\": 1, \"simpleMaybe\": \"TWO\", \"simpleList\":[\"ONE\",\"TWO\"], \"customMaybe\": 2,\"customList\":[1,2]}"));
   }
 
   @Test
@@ -37,10 +41,12 @@ public class WireSafeEnumTest {
     WireSafeBean bean = new WireSafeBean();
     bean.setSimple(WireSafeEnum.of(SimpleEnum.ONE));
     bean.setSimpleMaybe(Optional.of(WireSafeEnum.of(SimpleEnum.TWO)));
+    bean.setSimpleList(ImmutableList.of(WireSafeEnum.of(SimpleEnum.ONE), WireSafeEnum.of(SimpleEnum.TWO)));
     bean.setCustom(WireSafeEnum.of(CustomEnum.TWO));
     bean.setCustomMaybe(Optional.of(WireSafeEnum.of(CustomEnum.ONE)));
+    bean.setCustomList(ImmutableList.of(WireSafeEnum.of(CustomEnum.ONE), WireSafeEnum.of(CustomEnum.TWO)));
 
-    assertThat(deserialize("{\"simple\": \"ONE\", \"simpleMaybe\": \"TWO\", \"custom\": 2, \"customMaybe\": 1}", WireSafeBean.class)).isEqualTo(bean);
+    assertThat(deserialize("{\"simple\": \"ONE\", \"simpleMaybe\": \"TWO\", \"custom\": 2, \"customMaybe\": 1, \"simpleList\":[\"ONE\",\"TWO\"], \"customList\":[1,2]}", WireSafeBean.class)).isEqualTo(bean);
   }
 
   @Test
@@ -49,7 +55,16 @@ public class WireSafeEnumTest {
     bean.setSimple(WireSafeEnum.of(SimpleEnum.ONE));
     bean.setCustom(WireSafeEnum.of(CustomEnum.ONE));
 
-    assertThat(serialize(bean)).isEqualTo(asNode("{\"simple\": \"ONE\", \"custom\": 1, \"simpleMaybe\": null, \"customMaybe\": null}"));
+    assertThat(serialize(bean)).isEqualTo(asNode("{\"simple\": \"ONE\", \"custom\": 1, \"simpleMaybe\": null, \"customMaybe\": null, \"simpleList\": null, \"customList\": null}"));
+  }
+
+  @Test
+  public void itCanSerializeEmptyListWireSafeFields() {
+    WireSafeBean bean = new WireSafeBean();
+    bean.setSimpleList(Collections.emptyList());
+    bean.setCustomList(Collections.emptyList());
+
+    assertThat(serialize(bean)).isEqualTo(asNode("{\"simple\": null, \"simpleMaybe\": null, \"simpleList\": [], \"custom\": null, \"customMaybe\": null, \"customList\": []}"));
   }
 
   @Test

--- a/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/WireSafeEnumTest.java
+++ b/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/WireSafeEnumTest.java
@@ -30,10 +30,19 @@ public class WireSafeEnumTest {
     bean.setCustom(WireSafeEnum.of(CustomEnum.ONE));
     bean.setSimpleMaybe(Optional.of(WireSafeEnum.of(SimpleEnum.TWO)));
     bean.setCustomMaybe(Optional.of(WireSafeEnum.of(CustomEnum.TWO)));
-    bean.setSimpleList(ImmutableList.of(WireSafeEnum.of(SimpleEnum.ONE), WireSafeEnum.of(SimpleEnum.TWO)));
-    bean.setCustomList(ImmutableList.of(WireSafeEnum.of(CustomEnum.ONE), WireSafeEnum.of(CustomEnum.TWO)));
+    bean.setSimpleList(
+        ImmutableList.of(WireSafeEnum.of(SimpleEnum.ONE), WireSafeEnum.of(SimpleEnum.TWO))
+    );
+    bean.setCustomList(
+        ImmutableList.of(WireSafeEnum.of(CustomEnum.ONE), WireSafeEnum.of(CustomEnum.TWO))
+    );
 
-    assertThat(serialize(bean)).isEqualTo(asNode("{\"simple\": \"ONE\", \"custom\": 1, \"simpleMaybe\": \"TWO\", \"simpleList\":[\"ONE\",\"TWO\"], \"customMaybe\": 2,\"customList\":[1,2]}"));
+    assertThat(serialize(bean))
+        .isEqualTo(
+            asNode(
+                "{\"simple\": \"ONE\", \"custom\": 1, \"simpleMaybe\": \"TWO\", \"simpleList\":[\"ONE\",\"TWO\"], \"customMaybe\": 2,\"customList\":[1,2]}"
+            )
+        );
   }
 
   @Test
@@ -41,12 +50,22 @@ public class WireSafeEnumTest {
     WireSafeBean bean = new WireSafeBean();
     bean.setSimple(WireSafeEnum.of(SimpleEnum.ONE));
     bean.setSimpleMaybe(Optional.of(WireSafeEnum.of(SimpleEnum.TWO)));
-    bean.setSimpleList(ImmutableList.of(WireSafeEnum.of(SimpleEnum.ONE), WireSafeEnum.of(SimpleEnum.TWO)));
+    bean.setSimpleList(
+        ImmutableList.of(WireSafeEnum.of(SimpleEnum.ONE), WireSafeEnum.of(SimpleEnum.TWO))
+    );
     bean.setCustom(WireSafeEnum.of(CustomEnum.TWO));
     bean.setCustomMaybe(Optional.of(WireSafeEnum.of(CustomEnum.ONE)));
-    bean.setCustomList(ImmutableList.of(WireSafeEnum.of(CustomEnum.ONE), WireSafeEnum.of(CustomEnum.TWO)));
+    bean.setCustomList(
+        ImmutableList.of(WireSafeEnum.of(CustomEnum.ONE), WireSafeEnum.of(CustomEnum.TWO))
+    );
 
-    assertThat(deserialize("{\"simple\": \"ONE\", \"simpleMaybe\": \"TWO\", \"custom\": 2, \"customMaybe\": 1, \"simpleList\":[\"ONE\",\"TWO\"], \"customList\":[1,2]}", WireSafeBean.class)).isEqualTo(bean);
+    assertThat(
+        deserialize(
+            "{\"simple\": \"ONE\", \"simpleMaybe\": \"TWO\", \"custom\": 2, \"customMaybe\": 1, \"simpleList\":[\"ONE\",\"TWO\"], \"customList\":[1,2]}",
+            WireSafeBean.class
+        )
+    )
+        .isEqualTo(bean);
   }
 
   @Test
@@ -55,7 +74,12 @@ public class WireSafeEnumTest {
     bean.setSimple(WireSafeEnum.of(SimpleEnum.ONE));
     bean.setCustom(WireSafeEnum.of(CustomEnum.ONE));
 
-    assertThat(serialize(bean)).isEqualTo(asNode("{\"simple\": \"ONE\", \"custom\": 1, \"simpleMaybe\": null, \"customMaybe\": null, \"simpleList\": null, \"customList\": null}"));
+    assertThat(serialize(bean))
+        .isEqualTo(
+            asNode(
+                "{\"simple\": \"ONE\", \"custom\": 1, \"simpleMaybe\": null, \"customMaybe\": null, \"simpleList\": null, \"customList\": null}"
+            )
+        );
   }
 
   @Test
@@ -64,7 +88,12 @@ public class WireSafeEnumTest {
     bean.setSimpleList(Collections.emptyList());
     bean.setCustomList(Collections.emptyList());
 
-    assertThat(serialize(bean)).isEqualTo(asNode("{\"simple\": null, \"simpleMaybe\": null, \"simpleList\": [], \"custom\": null, \"customMaybe\": null, \"customList\": []}"));
+    assertThat(serialize(bean))
+        .isEqualTo(
+            asNode(
+                "{\"simple\": null, \"simpleMaybe\": null, \"simpleList\": [], \"custom\": null, \"customMaybe\": null, \"customList\": []}"
+            )
+        );
   }
 
   @Test
@@ -74,7 +103,13 @@ public class WireSafeEnumTest {
     bean.setSimpleMaybe(Optional.empty());
     bean.setCustom(WireSafeEnum.of(CustomEnum.TWO));
 
-    assertThat(deserialize("{\"simple\": \"ONE\", \"simpleMaybe\": null, \"custom\": 2 }", WireSafeBean.class)).isEqualTo(bean);
+    assertThat(
+        deserialize(
+            "{\"simple\": \"ONE\", \"simpleMaybe\": null, \"custom\": 2 }",
+            WireSafeBean.class
+        )
+    )
+        .isEqualTo(bean);
   }
 
   private JsonNode asNode(String value) {

--- a/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/beans/WireSafeBean.java
+++ b/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/beans/WireSafeBean.java
@@ -1,5 +1,6 @@
 package com.hubspot.rosetta.immutables.beans;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.google.common.base.MoreObjects;
@@ -9,8 +10,10 @@ import com.hubspot.immutables.utils.WireSafeEnum;
 public class WireSafeBean {
   private WireSafeEnum<SimpleEnum> simple;
   private Optional<WireSafeEnum<SimpleEnum>> simpleMaybe;
+  private List<WireSafeEnum<SimpleEnum>> simpleList;
   private WireSafeEnum<CustomEnum> custom;
   private Optional<WireSafeEnum<CustomEnum>> customMaybe;
+  private List<WireSafeEnum<CustomEnum>> customList;
 
   public WireSafeEnum<SimpleEnum> getSimple() {
       return simple;
@@ -18,6 +21,10 @@ public class WireSafeBean {
 
   public Optional<WireSafeEnum<SimpleEnum>> getSimpleMaybe() {
     return simpleMaybe;
+  }
+
+  public List<WireSafeEnum<SimpleEnum>> getSimpleList() {
+    return simpleList;
   }
 
   public WireSafeEnum<CustomEnum> getCustom() {
@@ -28,12 +35,20 @@ public class WireSafeBean {
     return customMaybe;
   }
 
+  public List<WireSafeEnum<CustomEnum>> getCustomList() {
+    return customList;
+  }
+
   public void setSimple(WireSafeEnum<SimpleEnum> simple) {
     this.simple = simple;
   }
 
   public void setSimpleMaybe(Optional<WireSafeEnum<SimpleEnum>> simpleMaybe) {
     this.simpleMaybe = simpleMaybe;
+  }
+
+  public void setSimpleList(List<WireSafeEnum<SimpleEnum>> simpleList) {
+    this.simpleList = simpleList;
   }
 
   public void setCustom(WireSafeEnum<CustomEnum> custom) {
@@ -44,14 +59,20 @@ public class WireSafeBean {
     this.customMaybe = customMaybe;
   }
 
+  public void setCustomList(List<WireSafeEnum<CustomEnum>> customList) {
+    this.customList = customList;
+  }
+
   @Override
   public String toString() {
     return MoreObjects
         .toStringHelper(WireSafeBean.class)
         .add("simple", simple)
         .add("simpleMaybe", simpleMaybe)
+        .add("simpleList", simpleList)
         .add("custom", custom)
         .add("customMaybe", customMaybe)
+        .add("customList", customList)
         .toString();
   }
 
@@ -68,12 +89,14 @@ public class WireSafeBean {
     WireSafeBean bean = (WireSafeBean) o;
     return Objects.equal(simple, bean.simple) &&
         Objects.equal(simpleMaybe, bean.simpleMaybe) &&
+        Objects.equal(simpleList, bean.simpleList) &&
         Objects.equal(custom, bean.custom) &&
-        Objects.equal(customMaybe, bean.customMaybe);
+        Objects.equal(customMaybe, bean.customMaybe) &&
+        Objects.equal(customList, bean.customList);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(simple, simpleMaybe, custom, customMaybe);
+    return Objects.hashCode(simple, simpleMaybe, simpleList, custom, customMaybe, customList);
   }
 }


### PR DESCRIPTION
Adding some additional contextual serialization handling for Lists of WireSafeEnums.

This is currently not supported and unblocks a team from making use of the missing functionality, so I suspect there isn't a risk to introducing any breaking changes.

@jhaber @kmclarnon @stevegutz (feel free to tag anyone I may have missed!)