### PR TITLE
Fix flaky test failure in StoredAsJsonTest#itHandlesAnnotatedOptionalGenericSetterSerialization

### DIFF
--- a/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/StoredAsJsonTest.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/StoredAsJsonTest.java
@@ -10,7 +10,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.BinaryNode;
@@ -40,7 +39,6 @@ import com.hubspot.rosetta.beans.StoredAsJsonListTypeInfoBean;
 import com.hubspot.rosetta.beans.StoredAsJsonListTypeInfoBean.ConcreteStoredAsJsonList;
 import com.hubspot.rosetta.beans.StoredAsJsonTypeInfoBean;
 import com.hubspot.rosetta.beans.StoredAsJsonTypeInfoBean.ConcreteStoredAsJsonTypeInfo;
-@JsonPropertyOrder({"generalValue", "General","concreteValue","internal","type","concrete"})
 public class StoredAsJsonTest {
   private StoredAsJsonBean bean;
   private InnerBean inner;

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/StoredAsJsonTest.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/StoredAsJsonTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.BinaryNode;
@@ -39,7 +40,7 @@ import com.hubspot.rosetta.beans.StoredAsJsonListTypeInfoBean;
 import com.hubspot.rosetta.beans.StoredAsJsonListTypeInfoBean.ConcreteStoredAsJsonList;
 import com.hubspot.rosetta.beans.StoredAsJsonTypeInfoBean;
 import com.hubspot.rosetta.beans.StoredAsJsonTypeInfoBean.ConcreteStoredAsJsonTypeInfo;
-
+@JsonPropertyOrder({"generalValue", "General","concreteValue","internal","type","concrete"})
 public class StoredAsJsonTest {
   private StoredAsJsonBean bean;
   private InnerBean inner;

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonBean.java
@@ -1,11 +1,9 @@
 package com.hubspot.rosetta.beans;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.hubspot.rosetta.annotations.StoredAsJson;
-@JsonPropertyOrder({"generalValue", "General","concreteValue","internal","type","concrete"})
 public class StoredAsJsonBean {
   private static final CastToSuper CAST_TO_SUPER = new CastToSuper();
 

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonBean.java
@@ -1,10 +1,11 @@
 package com.hubspot.rosetta.beans;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.hubspot.rosetta.annotations.StoredAsJson;
-
+@JsonPropertyOrder({"generalValue", "General","concreteValue","internal","type","concrete"})
 public class StoredAsJsonBean {
   private static final CastToSuper CAST_TO_SUPER = new CastToSuper();
 

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonTypeInfoBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/StoredAsJsonTypeInfoBean.java
@@ -1,5 +1,6 @@
 package com.hubspot.rosetta.beans;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
@@ -10,6 +11,7 @@ import com.hubspot.rosetta.beans.StoredAsJsonTypeInfoBean.ConcreteStoredAsJsonTy
 @JsonSubTypes({
     @JsonSubTypes.Type(value = ConcreteStoredAsJsonTypeInfo.class, name = "concrete")
 })
+@JsonPropertyOrder({"generalValue", "General","concreteValue","internal","type","concrete"})
 public interface StoredAsJsonTypeInfoBean {
 
   String getType();


### PR DESCRIPTION
### **What is the purpose of this PR**

This PR fixes flaky test failure on- com.hubspot.rosetta.annotations.StoredAsJsonTest#itHandlesAnnotatedOptionalGenericSetterSerialization

### **Why the test fails**
The flakiness is due to the use of object mapper function [valueToTree](https://fasterxml.github.io/jackson-databind/javadoc/2.8/com/fasterxml/jackson/databind/ObjectMapper.html#valueToTree(java.lang.Object)). Its functionally similar to serializing value into JSON and parsing JSON as tree. While results are usually identical to that of serialization followed by deserialization, this is not always the case. In some cases serialization into intermediate representation will retain encapsulation of things like [raw value](https://fasterxml.github.io/jackson-databind/javadoc/2.8/com/fasterxml/jackson/databind/util/RawValue.html) or basic node identity [JsonNode](https://fasterxml.github.io/jackson-databind/javadoc/2.8/com/fasterxml/jackson/databind/JsonNode.html). If so, result is a valid tree, but values are not re-constructed through actual JSON representation. This nondeterministic behavior causes the flakiness in the program.


### **Reproducing the test failure**

- Version of asset-share-commons
SHA: https://github.com/HubSpot/Rosetta/commit/52fb2eca2d03eb10ce50fa56bd2f7bafaf82a41b

- JVM version
   jdk1.8.0_202
   Apache Maven 3.8.6

- Clone repository 
   

   -> git clone https://github.com/HubSpot/Rosetta
   -> cd Rosetta
   -> git checkout 52fb2eca2d03eb10ce50fa56bd2f7bafaf82a41b

-  Install dependencies
   -> mvn clean install -DskipTests -pl RosettaCore -am

-    Run test with [Nondex tool](https://github.com/TestingResearchIllinois/NonDex) (which explores different behaviors of under- determined APIs and reports test failures)
  -> mvn -pl RosettaCore edu.illinois:nondex-maven-plugin:1.1.2:nondex 
 -Dtest=com.hubspot.rosetta.annotations.StoredAsJsonTest#itHandlesAnnotatedOptionalGenericSetterSerialization
 
 ### **Expected Result**

-  All the tests should pass

 
### **Actual Result**
- One of the test fails
-  Sample failure log when tested with  Nondex 
   [failbeforefix.log](https://github.com/HubSpot/Rosetta/files/9952337/failbeforefix.log)

### **Proposed fix and result**
- This proposed method to fix the flakiness uses  [JsonPropertyOrder](https://fasterxml.github.io/jackson-annotations/javadoc/2.8/com/fasterxml/jackson/annotation/JsonPropertyOrder.html). It can be used to define ordering to use when serializing object properties. Properties included in annotation declaration will be serialized first (in defined order), followed by any properties not included in the definition.

- Sample Nondex Log after the implementation of our proposed method which removes the flakiness
[passafterfix.log](https://github.com/HubSpot/Rosetta/files/9952352/passafterfix.log)
