### PR TITLE
Bump jdbi to 3.28.0

### DIFF
--- a/RosettaJdbi3/pom.xml
+++ b/RosettaJdbi3/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>RosettaJdbi3</artifactId>
 
   <properties>
-    <dep.slf4j.version>1.7.25</dep.slf4j.version>
+    <dep.slf4j.version>1.7.32</dep.slf4j.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
       <dependency>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-core</artifactId>
-        <version>3.1.1</version>
+        <version>3.28.0</version>
       </dependency>
       <dependency>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-sqlobject</artifactId>
-        <version>3.1.1</version>
+        <version>3.28.0</version>
       </dependency>
       <dependency>
         <groupId>com.h2database</groupId>


### PR DESCRIPTION
In the current version of jdbi that this project uses (3.1.1), `Statement#bindList` takes a string and a `java.util.List<?>` as parameters, however in the version of jdbi3 that we are using internally (3.28.0), `Statement#bindList` has been changed to have several different overloads, but importantly the `Statement#bindList(String, List<?>)` has been altered to be `Statement#bindList(String, Iterable<?>)` which is binary incompatible, resulting in internal applications seeing `NoSuchMethod` errors when trying to use `@BindListWithRosetta`

The slf4j version bump was required for the jdbi bump.

@stevie400 @jhaber @Xcelled @jaredstehler 