### PR TITLE
Optional nested beans support for join results

### DIFF
--- a/RosettaAnnotations/src/main/java/com/hubspot/rosetta/annotations/NestedOptional.java
+++ b/RosettaAnnotations/src/main/java/com/hubspot/rosetta/annotations/NestedOptional.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicate that a field is a nested optional and serde operations will follow nested optional rules.
+ * Indicate that a field is a nested optional and deserialization will follow the nested optional rules.
  */
 @Target({ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/RosettaAnnotations/src/main/java/com/hubspot/rosetta/annotations/NestedOptional.java
+++ b/RosettaAnnotations/src/main/java/com/hubspot/rosetta/annotations/NestedOptional.java
@@ -1,0 +1,15 @@
+package com.hubspot.rosetta.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicate that a field is a nested optional and serde operations will follow nested optional rules.
+ */
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@RosettaAnnotation
+public @interface NestedOptional {
+}

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/Rosetta.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/Rosetta.java
@@ -48,6 +48,7 @@ public enum Rosetta {
       mapper.registerModule(module);
     }
 
+
     return mapper;
   }
 

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/Rosetta.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/Rosetta.java
@@ -48,7 +48,6 @@ public enum Rosetta {
       mapper.registerModule(module);
     }
 
-
     return mapper;
   }
 

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/NestedOptionalDeserializer.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/NestedOptionalDeserializer.java
@@ -1,0 +1,55 @@
+package com.hubspot.rosetta.internal;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+
+public class NestedOptionalDeserializer<T> extends StdScalarDeserializer<Optional<T>> {
+
+  private final Class<T> referencedClazz;
+
+  public NestedOptionalDeserializer(Class<Optional<T>> clazz, Class<T> referencedClazz) {
+    super(clazz);
+    this.referencedClazz = referencedClazz;
+  }
+
+  @Override
+  public Optional<T> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
+
+    JsonNode root = mapper.readValue(jp, JsonNode.class);
+
+    return convert(root, mapper);
+  }
+
+  private Optional<T> convert(JsonNode root, ObjectMapper mapper) throws IOException {
+    if (root.isNull()) {
+      return Optional.empty();
+    }
+
+    Iterator<String> fieldNames = root.fieldNames();
+
+    if (!fieldNames.hasNext()) {
+      throw new IllegalArgumentException("The provided object has no fields: " + root);
+    }
+
+    while (fieldNames.hasNext()) {
+      String fieldName = fieldNames.next();
+
+      if (!root.get(fieldName).isNull()) {
+        return Optional.of(
+            mapper.treeToValue(root, referencedClazz)
+        );
+      }
+    }
+
+    return Optional.empty();
+  }
+
+}

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/NestedOptionalTest.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/NestedOptionalTest.java
@@ -1,0 +1,27 @@
+package com.hubspot.rosetta.annotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.hubspot.rosetta.Rosetta;
+import com.hubspot.rosetta.beans.InnerBean;
+import com.hubspot.rosetta.beans.NestedOptionalBean;
+
+public class NestedOptionalTest {
+
+  @Test
+  public void testAnnotatedFieldDeserialization() throws IOException {
+    String nestedOptionalBeanJson = "" +
+        "{\"firstNestedOptional\":{\"stringProperty\":\"value-1\"}, " +
+        "\"secondNestedOptional\":{\"firstStringProperty\": null, \"secondStringProperty\": null}}";
+
+    NestedOptionalBean bean = Rosetta.getMapper().readValue(nestedOptionalBeanJson, NestedOptionalBean.class);
+
+    assertThat(bean.getFirstNestedOptional().map(InnerBean::getStringProperty)).contains("value-1");
+    assertThat(bean.getSecondNestedOptional()).isEmpty();
+  }
+
+}

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/MoreFieldsInnerFieldBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/MoreFieldsInnerFieldBean.java
@@ -1,0 +1,22 @@
+package com.hubspot.rosetta.beans;
+
+public class MoreFieldsInnerFieldBean {
+  private String firstStringProperty;
+  private String secondStringProperty;
+
+  public String getFirstStringProperty() {
+    return firstStringProperty;
+  }
+
+  public void setFirstStringProperty(String firstStringProperty) {
+    this.firstStringProperty = firstStringProperty;
+  }
+
+  public String getSecondStringProperty() {
+    return secondStringProperty;
+  }
+
+  public void setSecondStringProperty(String secondStringProperty) {
+    this.secondStringProperty = secondStringProperty;
+  }
+}

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/NestedOptionalBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/NestedOptionalBean.java
@@ -1,0 +1,30 @@
+package com.hubspot.rosetta.beans;
+
+import java.util.Optional;
+
+import com.hubspot.rosetta.annotations.NestedOptional;
+
+public class NestedOptionalBean {
+
+  @NestedOptional
+  private Optional<InnerBean> firstNestedOptional;
+
+  @NestedOptional
+  private Optional<MoreFieldsInnerFieldBean> secondNestedOptional;
+
+  public Optional<InnerBean> getFirstNestedOptional() {
+    return firstNestedOptional;
+  }
+
+  public void setFirstNestedOptional(Optional<InnerBean> firstNestedOptional) {
+    this.firstNestedOptional = firstNestedOptional;
+  }
+
+  public Optional<MoreFieldsInnerFieldBean> getSecondNestedOptional() {
+    return secondNestedOptional;
+  }
+
+  public void setSecondNestedOptional(Optional<MoreFieldsInnerFieldBean> secondNestedOptional) {
+    this.secondNestedOptional = secondNestedOptional;
+  }
+}


### PR DESCRIPTION
## Description

The proposed feature deals with deserialisation of optional nested beans, which is required when dealing with a result of a `LEFT JOIN` and view beans.

## The Problem

Let's suppose we've got two tables for `Foo` and `Bar` objects namely `foos` and `bars`, we'd like to fetch a view object `FooBar` which is a result of a:

```
select foo.foo_prop, bar.bar_prop_one, bar.bar_prop_two FROM foo LEFT JOIN bar on foo.bar_id = bar.id;
```

while the bean itself has the following structure:

```
class FooBar {
  Foo getFoo(); // some Foo property
  Optional<Bar> getBar();
}
```

Naturally, we might not find some `Bar`s however the result of the query will be a json of the form:

```
{
  "foo": {
    "foo_prop": "someValue"
  },
  "bar": {
    "bar_prop_one": null,
    "bar_prop_two": null
  },
  (...) // other fields
}
```

which will result in a deserialisation error of the `Optional<Bar>` as for it to work correctly it would need to get either `null` or no `bar` at all.

Currently, we would need to use an intermediate structure to fetch the results, including an 'all Optional' version of `Bar`:

```
class BarView {
  Optional<String> getBarPropOne();
  Optional<String> getBarPropTwo();
}
```

 which for more verbose objects may be cumbersome.

## Proposed Solution

This PR introduces the `NestedOptionalDeserializer<>` which checks whether **all fields** are `null` and if it is the case, provides an empty `Optional<>` as a result, hence getting rid of the intermediate structures.

The `@NestedOptional` annotation is introduced so that `Rosetta` can recognise that the above rule should be applied, providing a simple way to control this behavior.

## WIP

Please note, this PR is only a bare minimum to illustrate the issue and a possible solution, so the tests and the naming are likely to change - also, additional effort will be put forward to check the performance of the changes if the proposal is accepted. 