### PR TITLE
Ignore Map.Entry in RosettaRowMapperFactory

### DIFF
--- a/RosettaJdbi3/src/main/java/com/hubspot/rosetta/jdbi3/RosettaRowMapperFactory.java
+++ b/RosettaJdbi3/src/main/java/com/hubspot/rosetta/jdbi3/RosettaRowMapperFactory.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.rosetta.RosettaMapper;
 import com.hubspot.rosetta.util.SqlTableNameExtractor;
 import java.lang.reflect.Type;
+import java.util.Map;
 import java.util.Optional;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.generic.GenericTypes;
@@ -35,7 +36,12 @@ public class RosettaRowMapperFactory implements RowMapperFactory {
   private static boolean accepts(Type type, ConfigRegistry config) {
     Class<?> rawType = GenericTypes.getErasedType(type);
 
-    if (rawType.isPrimitive() || rawType.isArray() || rawType.isAnnotation()) {
+    if (
+      rawType.isPrimitive() ||
+      rawType.isArray() ||
+      rawType.isAnnotation() ||
+      rawType.equals(Map.Entry.class)
+    ) {
       return false;
     } else if (rawType == Optional.class) {
       Optional<Type> optionalType = GenericTypes.findGenericParameter(

--- a/RosettaJdbi3/src/test/java/com/hubspot/rosetta/jdbi3/RosettaRowMapperFactoryTest.java
+++ b/RosettaJdbi3/src/test/java/com/hubspot/rosetta/jdbi3/RosettaRowMapperFactoryTest.java
@@ -3,6 +3,7 @@ package com.hubspot.rosetta.jdbi3;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Map;
 import org.junit.Test;
 
 public class RosettaRowMapperFactoryTest extends AbstractJdbiTest {
@@ -21,5 +22,8 @@ public class RosettaRowMapperFactoryTest extends AbstractJdbiTest {
 
     TestObject actual = results.get(0);
     assertThat(actual).isEqualTo(expected);
+
+    Map<Integer, TestObject> map = getDao().getAllMap();
+    assertThat(map).containsOnly(Map.entry(1, expected));
   }
 }

--- a/RosettaJdbi3/src/test/java/com/hubspot/rosetta/jdbi3/TestDao.java
+++ b/RosettaJdbi3/src/test/java/com/hubspot/rosetta/jdbi3/TestDao.java
@@ -1,7 +1,9 @@
 package com.hubspot.rosetta.jdbi3;
 
 import java.util.List;
+import java.util.Map;
 import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.config.KeyColumn;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapperFactory;
 import org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -11,6 +13,10 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 public interface TestDao extends SqlObject {
   @SqlQuery("SELECT * FROM test_table")
   List<TestObject> getAll();
+
+  @SqlQuery("SELECT * FROM test_table")
+  @KeyColumn("id")
+  Map<Integer, TestObject> getAllMap();
 
   @SqlQuery("SELECT * FROM test_list_table")
   List<TestListObject> getAllList();


### PR DESCRIPTION
It is currently intercepting cases where we want to use the built-in [MapEntryMapper](https://jdbi.org/#mapentry-mapping).

[MapEntryMapper.factory()](https://github.com/jdbi/jdbi/blob/18958cb2ca00def74f1bedc29363a66ca1db98b5/core/src/main/java/org/jdbi/v3/core/mapper/MapEntryMapper.java#L56) for reference.