### PR TITLE
Pin the release target to jdk8

### DIFF
--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
@@ -23,7 +23,6 @@ import com.hubspot.rosetta.annotations.RosettaSerializationProperty;
 import com.hubspot.rosetta.annotations.RosettaSerialize;
 import com.hubspot.rosetta.annotations.RosettaValue;
 import com.hubspot.rosetta.annotations.StoredAsJson;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -219,11 +218,12 @@ public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
   }
 
   private <T> Optional<T> getFirstNonEmpty(Supplier<Optional<T>>... suppliers) {
-    return Arrays
-      .stream(suppliers)
-      .map(Supplier::get)
-      .filter(Optional::isPresent)
-      .findFirst()
-      .orElse(Optional.empty());
+    for (Supplier<Optional<T>> supplier : suppliers) {
+      Optional<T> maybeValue = supplier.get();
+      if (maybeValue.isPresent()) {
+        return maybeValue;
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/RosettaJdbi3/src/test/java/com/hubspot/rosetta/jdbi3/RosettaRowMapperFactoryTest.java
+++ b/RosettaJdbi3/src/test/java/com/hubspot/rosetta/jdbi3/RosettaRowMapperFactoryTest.java
@@ -2,6 +2,7 @@ package com.hubspot.rosetta.jdbi3;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
@@ -24,6 +25,6 @@ public class RosettaRowMapperFactoryTest extends AbstractJdbiTest {
     assertThat(actual).isEqualTo(expected);
 
     Map<Integer, TestObject> map = getDao().getAllMap();
-    assertThat(map).containsOnly(Map.entry(1, expected));
+    assertThat(map).containsAllEntriesOf(Collections.singletonMap(1, expected));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,11 @@
         <module>RosettaImmutables</module>
     </modules>
 
+   <properties>
+        <project.build.releaseJdk>8</project.build.releaseJdk>
+        <project.build.targetJdk>8</project.build.targetJdk>
+   </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
As this is a core library used widely across many applications running various jdks we should continue to pin this to jdk8.

Related change in basepom https://github.com/HubSpot/basepom/pull/153

cc @jaredstehler @stevie400 @Xcelled 