### PR TITLE
Support for Jackson 2.18

### DIFF
--- a/RosettaAnnotations/pom.xml
+++ b/RosettaAnnotations/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.rosetta</groupId>
     <artifactId>Rosetta</artifactId>
-    <version>3.12.2-SNAPSHOT</version>
+    <version>3.13.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>RosettaAnnotations</artifactId>

--- a/RosettaCore/pom.xml
+++ b/RosettaCore/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.rosetta</groupId>
     <artifactId>Rosetta</artifactId>
-    <version>3.12.2-SNAPSHOT</version>
+    <version>3.13.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>RosettaCore</artifactId>

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
@@ -1,5 +1,9 @@
 package com.hubspot.rosetta.internal;
 
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import com.fasterxml.jackson.annotation.JsonCreator.Mode;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonInclude.Value;
 import com.fasterxml.jackson.core.Version;
@@ -7,6 +11,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyName;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
@@ -23,8 +28,6 @@ import com.hubspot.rosetta.annotations.RosettaSerializationProperty;
 import com.hubspot.rosetta.annotations.RosettaSerialize;
 import com.hubspot.rosetta.annotations.RosettaValue;
 import com.hubspot.rosetta.annotations.StoredAsJson;
-import java.util.Optional;
-import java.util.function.Supplier;
 
 public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
 
@@ -111,13 +114,11 @@ public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
   }
 
   @Override
-  public boolean hasAsValueAnnotation(AnnotatedMethod am) {
-    return am.hasAnnotation(RosettaValue.class);
-  }
-
-  @Override
-  public boolean hasCreatorAnnotation(Annotated a) {
-    return a.hasAnnotation(RosettaCreator.class);
+  public Mode findCreatorAnnotation(MapperConfig<?> config, Annotated ann) {
+    if (ann.hasAnnotation(RosettaCreator.class)) {
+      return Mode.DEFAULT;
+    }
+    return null;
   }
 
   @Override
@@ -141,16 +142,6 @@ public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
   }
 
   @Override
-  public Include findSerializationInclusion(Annotated a, Include defValue) {
-    return Include.ALWAYS;
-  }
-
-  @Override
-  public Include findSerializationInclusionForContent(Annotated a, Include defValue) {
-    return Include.ALWAYS;
-  }
-
-  @Override
   public Value findPropertyInclusion(Annotated a) {
     return Value.construct(Include.ALWAYS, Include.ALWAYS);
   }
@@ -166,7 +157,7 @@ public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
       // The super method can return null, so we can't use && here
       return false;
     } else {
-      return super.hasAsValue(a);
+      return a.hasAnnotation(RosettaValue.class);
     }
   }
 

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
@@ -1,8 +1,5 @@
 package com.hubspot.rosetta.internal;
 
-import java.util.Optional;
-import java.util.function.Supplier;
-
 import com.fasterxml.jackson.annotation.JsonCreator.Mode;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonInclude.Value;
@@ -28,6 +25,8 @@ import com.hubspot.rosetta.annotations.RosettaSerializationProperty;
 import com.hubspot.rosetta.annotations.RosettaSerialize;
 import com.hubspot.rosetta.annotations.RosettaValue;
 import com.hubspot.rosetta.annotations.StoredAsJson;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
 

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
@@ -25,6 +25,7 @@ import com.hubspot.rosetta.annotations.RosettaSerializationProperty;
 import com.hubspot.rosetta.annotations.RosettaSerialize;
 import com.hubspot.rosetta.annotations.RosettaValue;
 import com.hubspot.rosetta.annotations.StoredAsJson;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -151,6 +152,7 @@ public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
   }
 
   @Override
+  @SuppressFBWarnings("NP_BOOLEAN_RETURN_NULL")
   public Boolean hasAsValue(Annotated a) {
     if (a.hasAnnotation(RosettaIgnore.class)) {
       // The super method can return null, so we can't use && here

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospector.java
@@ -156,7 +156,7 @@ public class RosettaAnnotationIntrospector extends NopAnnotationIntrospector {
       // The super method can return null, so we can't use && here
       return false;
     } else {
-      return a.hasAnnotation(RosettaValue.class);
+      return a.hasAnnotation(RosettaValue.class) ? true : null;
     }
   }
 

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospectorPair.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospectorPair.java
@@ -1,0 +1,20 @@
+package com.hubspot.rosetta.internal;
+
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
+
+public class RosettaAnnotationIntrospectorPair extends AnnotationIntrospectorPair {
+
+  public RosettaAnnotationIntrospectorPair(
+    AnnotationIntrospector p,
+    AnnotationIntrospector s
+  ) {
+    super(p, s);
+  }
+
+  @Override
+  public boolean hasIgnoreMarker(AnnotatedMember m) {
+    return _primary.hasIgnoreMarker(m);
+  }
+}

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospectorPair.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaAnnotationIntrospectorPair.java
@@ -3,18 +3,35 @@ package com.hubspot.rosetta.internal;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 public class RosettaAnnotationIntrospectorPair extends AnnotationIntrospectorPair {
 
+  Set<Class<? extends Annotation>> overridingAnnotations;
+
   public RosettaAnnotationIntrospectorPair(
     AnnotationIntrospector p,
-    AnnotationIntrospector s
+    AnnotationIntrospector s,
+    Class<? extends Annotation>... overridingAnnotations
   ) {
     super(p, s);
+    this.overridingAnnotations =
+      new LinkedHashSet<>(Arrays.asList(overridingAnnotations));
   }
 
   @Override
   public boolean hasIgnoreMarker(AnnotatedMember m) {
-    return _primary.hasIgnoreMarker(m);
+    if (_primary.hasIgnoreMarker(m)) {
+      return true;
+    }
+
+    if (overridingAnnotations.stream().anyMatch(m::hasAnnotation)) {
+      return false;
+    }
+
+    return _secondary.hasIgnoreMarker(m);
   }
 }

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaModule.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaModule.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
+import com.hubspot.rosetta.annotations.RosettaDeserializationProperty;
+import com.hubspot.rosetta.annotations.RosettaProperty;
+import com.hubspot.rosetta.annotations.RosettaSerializationProperty;
 
 @SuppressWarnings("serial")
 public class RosettaModule extends Module {
@@ -35,7 +38,9 @@ public class RosettaModule extends Module {
           .with(
             new RosettaAnnotationIntrospectorPair(
               new RosettaAnnotationIntrospector(mapper),
-              mapper.getDeserializationConfig().getAnnotationIntrospector()
+              mapper.getDeserializationConfig().getAnnotationIntrospector(),
+              RosettaDeserializationProperty.class,
+              RosettaProperty.class
             )
           )
       );
@@ -46,12 +51,12 @@ public class RosettaModule extends Module {
           .with(
             new RosettaAnnotationIntrospectorPair(
               new RosettaAnnotationIntrospector(mapper),
-              mapper.getSerializationConfig().getAnnotationIntrospector()
+              mapper.getSerializationConfig().getAnnotationIntrospector(),
+              RosettaSerializationProperty.class,
+              RosettaProperty.class
             )
           )
       );
-
-      mapper.getSerializationConfig().with(new RosettaAnnotationIntrospector(mapper));
 
       mapper.setSerializerProvider(new DefaultSerializerProvider.Impl());
       mapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaModule.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/RosettaModule.java
@@ -29,7 +29,29 @@ public class RosettaModule extends Module {
     if (codec instanceof ObjectMapper) {
       ObjectMapper mapper = (ObjectMapper) codec;
 
-      context.insertAnnotationIntrospector(new RosettaAnnotationIntrospector(mapper));
+      mapper.setConfig(
+        mapper
+          .getDeserializationConfig()
+          .with(
+            new RosettaAnnotationIntrospectorPair(
+              new RosettaAnnotationIntrospector(mapper),
+              mapper.getDeserializationConfig().getAnnotationIntrospector()
+            )
+          )
+      );
+
+      mapper.setConfig(
+        mapper
+          .getSerializationConfig()
+          .with(
+            new RosettaAnnotationIntrospectorPair(
+              new RosettaAnnotationIntrospector(mapper),
+              mapper.getSerializationConfig().getAnnotationIntrospector()
+            )
+          )
+      );
+
+      mapper.getSerializationConfig().with(new RosettaAnnotationIntrospector(mapper));
 
       mapper.setSerializerProvider(new DefaultSerializerProvider.Impl());
       mapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);

--- a/RosettaCore/src/main/java/com/hubspot/rosetta/internal/StoredAsJsonDeserializer.java
+++ b/RosettaCore/src/main/java/com/hubspot/rosetta/internal/StoredAsJsonDeserializer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
@@ -51,7 +52,12 @@ public class StoredAsJsonDeserializer<T> extends StdScalarDeserializer<T> {
     ) {
       return mapper.readValue(jp, javaType);
     } else {
-      throw ctxt.mappingException("Expected JSON String");
+      throw ctxt.wrongTokenException(
+        jp,
+        javaType,
+        JsonToken.START_OBJECT,
+        "Expected JSON String"
+      );
     }
   }
 
@@ -66,7 +72,7 @@ public class StoredAsJsonDeserializer<T> extends StdScalarDeserializer<T> {
   }
 
   @Override
-  public T getNullValue() {
+  public T getNullValue(DeserializationContext ctxt) throws JsonMappingException {
     try {
       return deserialize(objectMapper, null, objectMapper.constructType(type));
     } catch (IOException e) {

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/RosettaCreatorTest.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/RosettaCreatorTest.java
@@ -3,6 +3,7 @@ package com.hubspot.rosetta.annotations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.rosetta.Rosetta;
+import com.hubspot.rosetta.beans.HasSingleValueWrapperPropBean;
 import com.hubspot.rosetta.beans.RosettaCreatorConstructorBean;
 import com.hubspot.rosetta.beans.RosettaCreatorMethodBean;
 import java.io.IOException;
@@ -26,5 +27,13 @@ public class RosettaCreatorTest {
       .getMapper()
       .readValue(JSON, RosettaCreatorMethodBean.class);
     assertThat(bean.getStringProperty()).isEqualTo("value");
+  }
+
+  @Test
+  public void itWorksOnJacksonMethods() throws IOException {
+    HasSingleValueWrapperPropBean bean = Rosetta
+      .getMapper()
+      .readValue("{\"singleValueWrapper\":\"foo\"}", HasSingleValueWrapperPropBean.class);
+    assertThat(bean.getSingleValueWrapper().get()).isEqualTo("foo");
   }
 }

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/RosettaValueTest.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/annotations/RosettaValueTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.hubspot.rosetta.Rosetta;
+import com.hubspot.rosetta.beans.HasSingleValueWrapperPropBean;
 import com.hubspot.rosetta.beans.RosettaValueBean;
+import com.hubspot.rosetta.beans.SingleValueWrapperBean;
 import org.junit.Test;
 
 public class RosettaValueTest {
@@ -15,5 +17,14 @@ public class RosettaValueTest {
     bean.setStringProperty("value");
 
     assertThat(Rosetta.getMapper().writeValueAsString(bean)).isEqualTo("\"value\"");
+  }
+
+  @Test
+  public void itCallsJacksonValueMethod() throws JsonProcessingException {
+    HasSingleValueWrapperPropBean bean = new HasSingleValueWrapperPropBean();
+    bean.setSingleValueWrapper(SingleValueWrapperBean.of("foo"));
+
+    assertThat(Rosetta.getMapper().writeValueAsString(bean))
+      .isEqualTo("{\"singleValueWrapper\":\"foo\"}");
   }
 }

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/HasSingleValueWrapperPropBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/HasSingleValueWrapperPropBean.java
@@ -1,0 +1,14 @@
+package com.hubspot.rosetta.beans;
+
+public class HasSingleValueWrapperPropBean {
+
+  private SingleValueWrapperBean singleValueWrapper;
+
+  public SingleValueWrapperBean getSingleValueWrapper() {
+    return singleValueWrapper;
+  }
+
+  public void setSingleValueWrapper(SingleValueWrapperBean singleValueWrapper) {
+    this.singleValueWrapper = singleValueWrapper;
+  }
+}

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/RosettaNamingBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/RosettaNamingBean.java
@@ -1,9 +1,9 @@
 package com.hubspot.rosetta.beans;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.hubspot.rosetta.annotations.RosettaNaming;
 
-@RosettaNaming(LowerCaseWithUnderscoresStrategy.class)
+@RosettaNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RosettaNamingBean {
 
   private String stringProperty;

--- a/RosettaCore/src/test/java/com/hubspot/rosetta/beans/SingleValueWrapperBean.java
+++ b/RosettaCore/src/test/java/com/hubspot/rosetta/beans/SingleValueWrapperBean.java
@@ -1,0 +1,23 @@
+package com.hubspot.rosetta.beans;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class SingleValueWrapperBean {
+
+  private final String value;
+
+  private SingleValueWrapperBean(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String get() {
+    return value;
+  }
+
+  @JsonCreator
+  public static SingleValueWrapperBean of(String value) {
+    return new SingleValueWrapperBean(value);
+  }
+}

--- a/RosettaImmutables/pom.xml
+++ b/RosettaImmutables/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.rosetta</groupId>
     <artifactId>Rosetta</artifactId>
-    <version>3.12.2-SNAPSHOT</version>
+    <version>3.13.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>RosettaImmutables</artifactId>

--- a/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaAwareWireSafeEnumDeserializer.java
+++ b/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaAwareWireSafeEnumDeserializer.java
@@ -31,7 +31,7 @@ public class RosettaAwareWireSafeEnumDeserializer
   @Override
   public WireSafeEnum<?> deserialize(JsonParser p, DeserializationContext ctxt)
     throws IOException {
-    throw ctxt.mappingException("Expected createContextual to be called");
+    throw JsonMappingException.from(p, "Expected createContextual to be called");
   }
 
   @SuppressWarnings("unchecked")
@@ -67,18 +67,20 @@ public class RosettaAwareWireSafeEnumDeserializer
     JavaType javaType = context.getContextualType();
 
     if (!WireSafeEnum.class.equals(javaType.getRawClass())) {
-      context.reportMappingException(
+      throw JsonMappingException.from(
+        context.getParser(),
         "Expected contextual type to be WireSafeEnum, got: " + javaType
       );
     } else {
       JavaType typeParameter = javaType.findTypeParameters(WireSafeEnum.class)[0];
       if (!typeParameter.isEnumType()) {
-        context.reportMappingException("Can not handle non-enum type: " + typeParameter);
+        throw JsonMappingException.from(
+          context.getParser(),
+          "Can not handle non-enum type: " + typeParameter
+        );
       } else {
         return typeParameter.getRawClass();
       }
     }
-
-    throw new IllegalStateException(); // should never get here
   }
 }

--- a/RosettaJdbi/pom.xml
+++ b/RosettaJdbi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.rosetta</groupId>
     <artifactId>Rosetta</artifactId>
-    <version>3.12.2-SNAPSHOT</version>
+    <version>3.13.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>RosettaJdbi</artifactId>

--- a/RosettaJdbi3/pom.xml
+++ b/RosettaJdbi3/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.rosetta</groupId>
     <artifactId>Rosetta</artifactId>
-    <version>3.12.2-SNAPSHOT</version>
+    <version>3.13.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>RosettaJdbi3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,11 @@
     </modules>
 
    <properties>
-        <project.build.releaseJdk>8</project.build.releaseJdk>
-        <project.build.targetJdk>8</project.build.targetJdk>
+       <project.build.releaseJdk>8</project.build.releaseJdk>
+       <project.build.targetJdk>8</project.build.targetJdk>
+
+       <dep.jackson-databind.version>${dep.jackson.version}</dep.jackson-databind.version>
+       <dep.jackson.version>2.18.2</dep.jackson.version>
    </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.hubspot.rosetta</groupId>
     <artifactId>Rosetta</artifactId>
-    <version>3.12.2-SNAPSHOT</version>
+    <version>3.13.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>
         Rosetta is a Java library that leverages Jackson to take the pain out of


### PR DESCRIPTION
Code changes to support jackson 2.18, including handling some upstream deprecated method removals, and a semantic logic change in how JsonIgnore is handled -- https://github.com/FasterXML/jackson-databind/issues/3357

All the tests still pass with jackson 2.12, so I don't believe we need to raise the required minimum jackson version with this PR. I'm still bumping the minor version to indicate this is a larger change.

@suruuK 