### PR TITLE
Upgrade h2 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>2.1.210</version>
+                <version>2.3.232</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Used only in tests but still fixes usage of a version with CVE-2022-45868