### PR TITLE
🐉 Fix RosettaAwareWireSafeEnumDeserializer to handle unknown enum values gracefully

### DIFF
--- a/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaAwareWireSafeEnumDeserializer.java
+++ b/RosettaImmutables/src/main/java/com/hubspot/rosetta/immutables/RosettaAwareWireSafeEnumDeserializer.java
@@ -49,14 +49,13 @@ public class RosettaAwareWireSafeEnumDeserializer
   ) {
     return new JsonDeserializer<WireSafeEnum<?>>() {
       @Override
-      public WireSafeEnum<T> deserialize(JsonParser p, DeserializationContext ctxt) {
+      public WireSafeEnum<T> deserialize(JsonParser p, DeserializationContext ctxt)
+        throws IOException {
+        String rawValue = p.getText();
         try {
           return WireSafeEnum.of(p.getCodec().readValue(p, enumType));
         } catch (IOException e) {
-          throw new IllegalStateException(
-            "Invalid value for enum type: " + enumType.getTypeName(),
-            e
-          );
+          return WireSafeEnum.fromJson(enumType, rawValue);
         }
       }
     };

--- a/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/WireSafeEnumTest.java
+++ b/RosettaImmutables/src/test/java/com/hubspot/rosetta/immutables/WireSafeEnumTest.java
@@ -218,6 +218,23 @@ public class WireSafeEnumTest {
   }
 
   @Test
+  public void itDeserializesUnknownEnumValueGracefully() {
+    WireSafeBean bean = convert(
+      objectNode(
+        ImmutableMap
+          .<String, JsonNode>builder()
+          .put("simple", new TextNode("UNKNOWN_VALUE"))
+          .put("custom", new IntNode(1))
+          .build()
+      ),
+      WireSafeBean.class
+    );
+
+    assertThat(bean.getSimple().asEnum()).isEqualTo(Optional.empty());
+    assertThat(bean.getSimple().asString()).isEqualTo("UNKNOWN_VALUE");
+  }
+
+  @Test
   public void itCanDeserializeBeanWithEmptyWireSafeField() {
     WireSafeBean bean = new WireSafeBean();
     bean.setSimple(WireSafeEnum.of(SimpleEnum.ONE));


### PR DESCRIPTION
## Summary

`RosettaAwareWireSafeEnumDeserializer` throws `IllegalStateException` when it encounters an unknown enum value during database deserialization. This defeats the entire purpose of `WireSafeEnum`, which is designed to gracefully handle unknown enum constants by producing a `WireSafeEnum` with `enumValue = Optional.empty()`.

The fix captures the raw text value before `readValue` consumes the token, and on deserialization failure falls back to `WireSafeEnum.fromJson()` which creates the expected wire-safe representation of the unknown value.

Downstream issue: https://github.com/HubSpotEngineering/content-ai-platform/issues/2547

## Prompts used
- You are fixing a bug in the Rosetta library at /Users/jboulter/src/Rosetta. The bug is in `RosettaAwareWireSafeEnumDeserializer` — when it encounters an unknown enum value during database deserialization, it throws `IllegalStateException` instead of gracefully handling it via `WireSafeEnum.fromJson()`. This defeats the entire purpose of `WireSafeEnum`.

## Test plan
- [x] Added test `itDeserializesUnknownEnumValueGracefully` that verifies unknown enum values produce a `WireSafeEnum` with `asEnum() = Optional.empty()` and `asString() = "UNKNOWN_VALUE"`
- [x] All existing tests in RosettaImmutables module continue to pass